### PR TITLE
Unbreak build with libc++

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -5,6 +5,8 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 
+#include <sstream>
+
 void errorNotif() {
 	HyprlandAPI::addNotificationV2(PHANDLE, {
 		{"text", "Something has gone very wrong. Check the log for details."},


### PR DESCRIPTION
To test use `CXX=clang++` and `CXXFLAGS=-stdlib=libc++`. Default on FreeBSD and Chimera Linux. Note: OpenBSD, macOS, Android also use clang/libc++ but don't have wlroots yet.