### PR TITLE
Add a change group dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ plugin {
  - `hy3:makegroup, <h | v | opposite | tab>, [ephemeral | force_ephemeral]` - make a vertical / horizontal split or tab group
    - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
    - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
- - `hy3:changegroup, <h | v | tab | untab | opposite> - change the group the node belongs to, to a different layout
+ - `hy3:changegroup, <h | v | tab | untab | opposite>` - change the group the node belongs to, to a different layout
    - `untab` will untab the group if it was previously tabbed
    - `opposite` will toggle between horizontal and vertical layouts if the group is not tabbed.
  - `hy3:changeephemerality, <true | false>` - change the ephemerality of the group the node belongs to

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ plugin {
  - `hy3:changegroup, <h | v | tab | untab | opposite>` - change the group the node belongs to, to a different layout
    - `untab` will untab the group if it was previously tabbed
    - `opposite` will toggle between horizontal and vertical layouts if the group is not tabbed.
- - `hy3:changeephemerality, <true | false>` - change the ephemerality of the group the node belongs to
+ - `hy3:setephemeral, <true | false>` - change the ephemerality of the group the node belongs to
  - `hy3:movefocus, <l | u | d | r | left | down | up | right>, [visible]` - move the focus left, up, down, or right
    - `visible` - only move between visible nodes, not hidden tabs
  - `hy3:movewindow, <l | u | d | r | left | down | up | right>, [once]` - move a window left, up, down, or right

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ plugin {
    - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
  - `hy3:changegroup, <h | v | tab | untab> - change the group the node belongs to, to a different layout
    - `untab` will untab the group if it was previously tabbed
+ - `hy3:changeephemerality, <true | false>` - change the ephemerality of the group the node belongs to
  - `hy3:movefocus, <l | u | d | r | left | down | up | right>, [visible]` - move the focus left, up, down, or right
    - `visible` - only move between visible nodes, not hidden tabs
  - `hy3:movewindow, <l | u | d | r | left | down | up | right>, [once]` - move a window left, up, down, or right

--- a/README.md
+++ b/README.md
@@ -215,8 +215,9 @@ plugin {
  - `hy3:makegroup, <h | v | opposite | tab>, [ephemeral | force_ephemeral]` - make a vertical / horizontal split or tab group
    - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
    - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
- - `hy3:changegroup, <h | v | tab | untab> - change the group the node belongs to, to a different layout
+ - `hy3:changegroup, <h | v | tab | untab | opposite> - change the group the node belongs to, to a different layout
    - `untab` will untab the group if it was previously tabbed
+   - `opposite` will toggle between horizontal and vertical layouts if the group is not tabbed.
  - `hy3:changeephemerality, <true | false>` - change the ephemerality of the group the node belongs to
  - `hy3:movefocus, <l | u | d | r | left | down | up | right>, [visible]` - move the focus left, up, down, or right
    - `visible` - only move between visible nodes, not hidden tabs

--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ plugin {
  - `hy3:makegroup, <h | v | opposite | tab>, [ephemeral | force_ephemeral]` - make a vertical / horizontal split or tab group
    - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
    - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
+ - `hy3:changegroup, <h | v | tab | untab>, [ephemeral | force_ephemeral]` - change the group the node belongs to, to a different layout
+   - `untab` will untab the group if it was previously tabbed
+   - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
+   - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
  - `hy3:movefocus, <l | u | d | r | left | down | up | right>, [visible]` - move the focus left, up, down, or right
    - `visible` - only move between visible nodes, not hidden tabs
  - `hy3:movewindow, <l | u | d | r | left | down | up | right>, [once]` - move a window left, up, down, or right

--- a/README.md
+++ b/README.md
@@ -215,10 +215,8 @@ plugin {
  - `hy3:makegroup, <h | v | opposite | tab>, [ephemeral | force_ephemeral]` - make a vertical / horizontal split or tab group
    - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
    - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
- - `hy3:changegroup, <h | v | tab | untab>, [ephemeral | force_ephemeral]` - change the group the node belongs to, to a different layout
+ - `hy3:changegroup, <h | v | tab | untab> - change the group the node belongs to, to a different layout
    - `untab` will untab the group if it was previously tabbed
-   - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
-   - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
  - `hy3:movefocus, <l | u | d | r | left | down | up | right>, [visible]` - move the focus left, up, down, or right
    - `visible` - only move between visible nodes, not hidden tabs
  - `hy3:movewindow, <l | u | d | r | left | down | up | right>, [once]` - move a window left, up, down, or right

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -748,7 +748,6 @@ void Hy3Layout::makeOppositeGroupOnWorkspace(int workspace, GroupEphemeralityOpt
 
 void Hy3Layout::changeGroupOnWorkspace(int workspace, Hy3GroupLayout layout) {
 	auto* node = this->getWorkspaceFocusedNode(workspace);
-
 	if (node == nullptr) return;
 
 	this->changeGroupOn(*node, layout);
@@ -756,7 +755,6 @@ void Hy3Layout::changeGroupOnWorkspace(int workspace, Hy3GroupLayout layout) {
 
 void Hy3Layout::untabGroupOnWorkspace(int workspace) {
 	auto* node = this->getWorkspaceFocusedNode(workspace);
-
 	if (node == nullptr) return;
 
 	this->untabGroupOn(*node);
@@ -764,7 +762,6 @@ void Hy3Layout::untabGroupOnWorkspace(int workspace) {
 
 void Hy3Layout::changeGroupToOppositeOnWorkspace(int workspace) {
 	auto* node = this->getWorkspaceFocusedNode(workspace);
-
 	if (node == nullptr) return;
 
 	this->changeGroupToOppositeOn(*node);
@@ -772,7 +769,6 @@ void Hy3Layout::changeGroupToOppositeOnWorkspace(int workspace) {
 
 void Hy3Layout::changeGroupEphemeralityOnWorkspace(int workspace, bool ephemeral) {
 	auto* node = this->getWorkspaceFocusedNode(workspace);
-
 	if (node == nullptr) return;
 
 	this->changeGroupEphemeralityOn(*node, ephemeral);

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -765,6 +765,14 @@ void Hy3Layout::untabGroupOnWorkspace(int workspace) {
 	this->untabGroupOn(*node);
 }
 
+void Hy3Layout::changeGroupToOppositeOnWorkspace(int workspace) {
+	auto* node = this->getWorkspaceFocusedNode(workspace);
+
+	if (node == nullptr) return;
+
+	this->changeGroupToOppositeOn(*node);
+}
+
 void Hy3Layout::changeGroupEphemeralityOnWorkspace(int workspace, bool ephemeral) {
 	auto* node = this->getWorkspaceFocusedNode(workspace);
 
@@ -839,6 +847,16 @@ void Hy3Layout::untabGroupOn(Hy3Node& node) {
 	if (group.layout != Hy3GroupLayout::Tabbed) return;
 
 	changeGroupOn(node, group.previous_nontab_layout);
+}
+
+void Hy3Layout::changeGroupToOppositeOn(Hy3Node& node) {
+	if (node.parent == nullptr) return;
+
+	auto& group = node.parent->data.as_group;
+
+	if (group.layout == Hy3GroupLayout::Tabbed) return;
+	group.setLayout(group.layout == Hy3GroupLayout::SplitH ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH);
+	node.parent->recalcSizePosRecursive();
 }
 
 void Hy3Layout::changeGroupEphemeralityOn(Hy3Node& node, bool ephemeral) {

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -765,6 +765,14 @@ void Hy3Layout::untabGroupOnWorkspace(int workspace) {
 	this->untabGroupOn(*node);
 }
 
+void Hy3Layout::changeGroupEphemeralityOnWorkspace(int workspace, bool ephemeral) {
+	auto* node = this->getWorkspaceFocusedNode(workspace);
+
+	if (node == nullptr) return;
+
+	this->changeGroupEphemeralityOn(*node, ephemeral);
+}
+
 void Hy3Layout::makeGroupOn(
     Hy3Node* node,
     Hy3GroupLayout layout,
@@ -831,8 +839,13 @@ void Hy3Layout::untabGroupOn(Hy3Node& node) {
 	if (group.layout != Hy3GroupLayout::Tabbed) return;
 
 	changeGroupOn(node, group.previous_nontab_layout);
+}
 
+void Hy3Layout::changeGroupEphemeralityOn(Hy3Node& node, bool ephemeral) {
+	if (node.parent == nullptr) return;
 
+	auto& group = node.parent->data.as_group;
+	group.setEphemeral(ephemeral ? GroupEphemeralityOption::ForceEphemeral : GroupEphemeralityOption::Standard);
 }
 
 void Hy3Layout::shiftWindow(int workspace, ShiftDirection direction, bool once) {

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -746,10 +746,7 @@ void Hy3Layout::makeOppositeGroupOnWorkspace(int workspace, GroupEphemeralityOpt
 	this->makeOppositeGroupOn(node, ephemeral);
 }
 
-void Hy3Layout::changeGroupOnWorkspace(
-	int workspace,
-	Hy3GroupLayout layout
-) {
+void Hy3Layout::changeGroupOnWorkspace(int workspace, Hy3GroupLayout layout) {
 	auto* node = this->getWorkspaceFocusedNode(workspace);
 
 	if (node == nullptr) return;
@@ -801,10 +798,7 @@ void Hy3Layout::makeGroupOn(
 	node->intoGroup(layout, ephemeral);
 }
 
-void Hy3Layout::makeOppositeGroupOn(
-	Hy3Node* node,
-	GroupEphemeralityOption ephemeral
-) {
+void Hy3Layout::makeOppositeGroupOn(Hy3Node* node, GroupEphemeralityOption ephemeral) {
 	if (node == nullptr) return;
 
 	if (node->parent == nullptr) {
@@ -814,7 +808,7 @@ void Hy3Layout::makeOppositeGroupOn(
 
 	auto& group = node->parent->data.as_group;
 	auto layout
-		= group.layout == Hy3GroupLayout::SplitH ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH;
+	    = group.layout == Hy3GroupLayout::SplitH ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH;
 
 	if (group.children.size() == 1) {
 		group.setLayout(layout);
@@ -826,10 +820,7 @@ void Hy3Layout::makeOppositeGroupOn(
 	node->intoGroup(layout, ephemeral);
 }
 
-void Hy3Layout::changeGroupOn(
-	Hy3Node& node,
-	Hy3GroupLayout layout
-) {
+void Hy3Layout::changeGroupOn(Hy3Node& node, Hy3GroupLayout layout) {
 	if (node.parent == nullptr) {
 		makeGroupOn(&node, layout, GroupEphemeralityOption::Ephemeral);
 		return;
@@ -855,7 +846,9 @@ void Hy3Layout::changeGroupToOppositeOn(Hy3Node& node) {
 	auto& group = node.parent->data.as_group;
 
 	if (group.layout == Hy3GroupLayout::Tabbed) return;
-	group.setLayout(group.layout == Hy3GroupLayout::SplitH ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH);
+	group.setLayout(
+	    group.layout == Hy3GroupLayout::SplitH ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH
+	);
 	node.parent->recalcSizePosRecursive();
 }
 
@@ -863,7 +856,9 @@ void Hy3Layout::changeGroupEphemeralityOn(Hy3Node& node, bool ephemeral) {
 	if (node.parent == nullptr) return;
 
 	auto& group = node.parent->data.as_group;
-	group.setEphemeral(ephemeral ? GroupEphemeralityOption::ForceEphemeral : GroupEphemeralityOption::Standard);
+	group.setEphemeral(
+	    ephemeral ? GroupEphemeralityOption::ForceEphemeral : GroupEphemeralityOption::Standard
+	);
 }
 
 void Hy3Layout::shiftWindow(int workspace, ShiftDirection direction, bool once) {
@@ -1497,7 +1492,9 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 			if (group.layout != Hy3GroupLayout::Tabbed && group.children.size() == 2
 			    && std::find(group.children.begin(), group.children.end(), &node) != group.children.end())
 			{
-				group.setLayout(shiftIsVertical(direction) ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH);
+				group.setLayout(
+				    shiftIsVertical(direction) ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH
+				);
 			} else {
 				// wrap the root group in another group
 				this->nodes.push_back({

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -92,11 +92,13 @@ public:
 	void makeOppositeGroupOnWorkspace(int workspace, GroupEphemeralityOption);
 	void changeGroupOnWorkspace(int workspace, Hy3GroupLayout);
 	void untabGroupOnWorkspace(int workspace);
+	void changeGroupToOppositeOnWorkspace(int workspace);
 	void changeGroupEphemeralityOnWorkspace(int workspace, bool ephemeral);
 	void makeGroupOn(Hy3Node*, Hy3GroupLayout, GroupEphemeralityOption);
 	void makeOppositeGroupOn(Hy3Node*, GroupEphemeralityOption);
 	void changeGroupOn(Hy3Node&, Hy3GroupLayout);
 	void untabGroupOn(Hy3Node&);
+	void changeGroupToOppositeOn(Hy3Node&);
 	void changeGroupEphemeralityOn(Hy3Node&, bool ephemeral);
 	void shiftWindow(int workspace, ShiftDirection, bool once);
 	void shiftFocus(int workspace, ShiftDirection, bool visible);

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -90,8 +90,12 @@ public:
 
 	void makeGroupOnWorkspace(int workspace, Hy3GroupLayout, GroupEphemeralityOption);
 	void makeOppositeGroupOnWorkspace(int workspace, GroupEphemeralityOption);
+	void changeGroupOnWorkspace(int workspace, Hy3GroupLayout, GroupEphemeralityOption);
+	void untabGroupOnWorkspace(int workspace, GroupEphemeralityOption);
 	void makeGroupOn(Hy3Node*, Hy3GroupLayout, GroupEphemeralityOption);
 	void makeOppositeGroupOn(Hy3Node*, GroupEphemeralityOption);
+	void changeGroupOn(Hy3Node*, Hy3GroupLayout, GroupEphemeralityOption);
+	void untabGroupOn(Hy3Node*, GroupEphemeralityOption);
 	void shiftWindow(int workspace, ShiftDirection, bool once);
 	void shiftFocus(int workspace, ShiftDirection, bool visible);
 	void changeFocus(int workspace, FocusShift);

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -92,10 +92,12 @@ public:
 	void makeOppositeGroupOnWorkspace(int workspace, GroupEphemeralityOption);
 	void changeGroupOnWorkspace(int workspace, Hy3GroupLayout);
 	void untabGroupOnWorkspace(int workspace);
+	void changeGroupEphemeralityOnWorkspace(int workspace, bool ephemeral);
 	void makeGroupOn(Hy3Node*, Hy3GroupLayout, GroupEphemeralityOption);
 	void makeOppositeGroupOn(Hy3Node*, GroupEphemeralityOption);
 	void changeGroupOn(Hy3Node&, Hy3GroupLayout);
 	void untabGroupOn(Hy3Node&);
+	void changeGroupEphemeralityOn(Hy3Node&, bool ephemeral);
 	void shiftWindow(int workspace, ShiftDirection, bool once);
 	void shiftFocus(int workspace, ShiftDirection, bool visible);
 	void changeFocus(int workspace, FocusShift);

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -90,12 +90,12 @@ public:
 
 	void makeGroupOnWorkspace(int workspace, Hy3GroupLayout, GroupEphemeralityOption);
 	void makeOppositeGroupOnWorkspace(int workspace, GroupEphemeralityOption);
-	void changeGroupOnWorkspace(int workspace, Hy3GroupLayout, GroupEphemeralityOption);
-	void untabGroupOnWorkspace(int workspace, GroupEphemeralityOption);
+	void changeGroupOnWorkspace(int workspace, Hy3GroupLayout);
+	void untabGroupOnWorkspace(int workspace);
 	void makeGroupOn(Hy3Node*, Hy3GroupLayout, GroupEphemeralityOption);
 	void makeOppositeGroupOn(Hy3Node*, GroupEphemeralityOption);
-	void changeGroupOn(Hy3Node*, Hy3GroupLayout, GroupEphemeralityOption);
-	void untabGroupOn(Hy3Node*, GroupEphemeralityOption);
+	void changeGroupOn(Hy3Node&, Hy3GroupLayout);
+	void untabGroupOn(Hy3Node&);
 	void shiftWindow(int workspace, ShiftDirection, bool once);
 	void shiftFocus(int workspace, ShiftDirection, bool visible);
 	void changeFocus(int workspace, FocusShift);

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -57,25 +57,26 @@ void Hy3GroupData::collapseExpansions() {
 	}
 }
 
-void Hy3GroupData::updateLayout(
-	Hy3GroupLayout layout,
-	GroupEphemeralityOption ephemeral
+void Hy3GroupData::setLayout(
+	Hy3GroupLayout layout
 ) {
 	this->layout = layout;
 
 	if (layout != Hy3GroupLayout::Tabbed) {
 		this->previous_nontab_layout = layout;
 	}
+}
 
+void Hy3GroupData::setEphemeral(GroupEphemeralityOption ephemeral) {
 	switch (ephemeral) {
-		case GroupEphemeralityOption::ForceEphemeral:
-			this->ephemeral = true;
-			break;
 		case GroupEphemeralityOption::Standard:
 			this->ephemeral = false;
 			break;
+		case GroupEphemeralityOption::ForceEphemeral:
+			this->ephemeral = true;
+			break;
 		case GroupEphemeralityOption::Ephemeral:
-			// this->ephemeral stays the same
+			// no change
 			break;
 	}
 }

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -8,10 +8,15 @@
 
 // Hy3GroupData //
 
-Hy3GroupData::Hy3GroupData(Hy3GroupLayout layout): layout(layout) {}
+Hy3GroupData::Hy3GroupData(Hy3GroupLayout layout): layout(layout) {
+	if (layout != Hy3GroupLayout::Tabbed) {
+		this->previous_nontab_layout = layout;
+	}
+}
 
 Hy3GroupData::Hy3GroupData(Hy3GroupData&& from) {
 	this->layout = from.layout;
+	this->previous_nontab_layout = from.previous_nontab_layout;
 	this->children = std::move(from.children);
 	this->group_focused = from.group_focused;
 	this->expand_focused = from.expand_focused;
@@ -49,6 +54,29 @@ void Hy3GroupData::collapseExpansions() {
 	{
 		node->data.as_group.expand_focused = ExpandFocusType::NotExpanded;
 		node = node->data.as_group.focused_child;
+	}
+}
+
+void Hy3GroupData::updateLayout(
+	Hy3GroupLayout layout,
+	GroupEphemeralityOption ephemeral
+) {
+	this->layout = layout;
+
+	if (layout != Hy3GroupLayout::Tabbed) {
+		this->previous_nontab_layout = layout;
+	}
+
+	switch (ephemeral) {
+		case GroupEphemeralityOption::ForceEphemeral:
+			this->ephemeral = true;
+			break;
+		case GroupEphemeralityOption::Standard:
+			this->ephemeral = false;
+			break;
+		case GroupEphemeralityOption::Ephemeral:
+			// this->ephemeral stays the same
+			break;
 	}
 }
 

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -57,9 +57,7 @@ void Hy3GroupData::collapseExpansions() {
 	}
 }
 
-void Hy3GroupData::setLayout(
-	Hy3GroupLayout layout
-) {
+void Hy3GroupData::setLayout(Hy3GroupLayout layout) {
 	this->layout = layout;
 
 	if (layout != Hy3GroupLayout::Tabbed) {
@@ -69,15 +67,11 @@ void Hy3GroupData::setLayout(
 
 void Hy3GroupData::setEphemeral(GroupEphemeralityOption ephemeral) {
 	switch (ephemeral) {
-		case GroupEphemeralityOption::Standard:
-			this->ephemeral = false;
-			break;
-		case GroupEphemeralityOption::ForceEphemeral:
-			this->ephemeral = true;
-			break;
-		case GroupEphemeralityOption::Ephemeral:
-			// no change
-			break;
+	case GroupEphemeralityOption::Standard: this->ephemeral = false; break;
+	case GroupEphemeralityOption::ForceEphemeral: this->ephemeral = true; break;
+	case GroupEphemeralityOption::Ephemeral:
+		// no change
+		break;
 	}
 }
 

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -29,6 +29,7 @@ enum class ExpandFocusType {
 
 struct Hy3GroupData {
 	Hy3GroupLayout layout = Hy3GroupLayout::SplitH;
+	Hy3GroupLayout previous_nontab_layout = Hy3GroupLayout::SplitH;
 	std::list<Hy3Node*> children;
 	bool group_focused = true;
 	Hy3Node* focused_child = nullptr;
@@ -42,6 +43,7 @@ struct Hy3GroupData {
 
 	bool hasChild(Hy3Node* child);
 	void collapseExpansions();
+	void updateLayout(Hy3GroupLayout layout, GroupEphemeralityOption ephemeral);
 
 private:
 	Hy3GroupData(Hy3GroupData&&);

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -43,7 +43,8 @@ struct Hy3GroupData {
 
 	bool hasChild(Hy3Node* child);
 	void collapseExpansions();
-	void updateLayout(Hy3GroupLayout layout, GroupEphemeralityOption ephemeral);
+	void setLayout(Hy3GroupLayout layout);
+	void setEphemeral(GroupEphemeralityOption ephemeral);
 
 private:
 	Hy3GroupData(Hy3GroupData&&);

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -43,6 +43,35 @@ void dispatch_makegroup(std::string value) {
 	}
 }
 
+void dispatch_changegroup(std::string value) {
+	int workspace = workspace_for_action();
+	if (workspace == -1) return;
+
+	auto args = CVarList(value);
+
+	GroupEphemeralityOption ephemeral = GroupEphemeralityOption::Standard;
+	if (args[1] == "ephemeral") {
+		ephemeral = GroupEphemeralityOption::Ephemeral;
+	} else if (args[1] == "force_ephemeral") {
+		ephemeral = GroupEphemeralityOption::ForceEphemeral;
+	}
+
+	if (args[0] == "h") {
+		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::SplitH, ephemeral);
+	} else if (args[0] == "v") {
+		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::SplitV, ephemeral);
+	} else if (args[0] == "tab") {
+		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::Tabbed, ephemeral);
+	} else if (args[0] == "untab") {
+		g_Hy3Layout->untabGroupOnWorkspace(workspace, ephemeral);
+	}
+	// TODO
+	//else if (args[0] == "opposite") {
+	//	g_Hy3Layout->makeOppositeGroupOnWorkspace(workspace, ephemeral);
+	//}
+}
+
+
 std::optional<ShiftDirection> parseShiftArg(std::string arg) {
 	if (arg == "l" || arg == "left") return ShiftDirection::Left;
 	else if (arg == "r" || arg == "right") return ShiftDirection::Right;
@@ -188,6 +217,7 @@ void dispatch_debug(std::string arg) {
 
 void registerDispatchers() {
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:makegroup", dispatch_makegroup);
+	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changegroup", dispatch_changegroup);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:movefocus", dispatch_movefocus);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:movewindow", dispatch_movewindow);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changefocus", dispatch_changefocus);

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -73,7 +73,6 @@ void dispatch_changeephemerality(std::string value) {
 	g_Hy3Layout->changeGroupEphemeralityOnWorkspace(workspace, ephemeral);
 }
 
-
 std::optional<ShiftDirection> parseShiftArg(std::string arg) {
 	if (arg == "l" || arg == "left") return ShiftDirection::Left;
 	else if (arg == "r" || arg == "right") return ShiftDirection::Right;

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -64,6 +64,17 @@ void dispatch_changegroup(std::string value) {
 	//}
 }
 
+void dispatch_changeephemerality(std::string value) {
+	int workspace = workspace_for_action();
+	if (workspace == -1) return;
+
+	auto args = CVarList(value);
+
+	bool ephemeral = args[0] == "true";
+
+	g_Hy3Layout->changeGroupEphemeralityOnWorkspace(workspace, ephemeral);
+}
+
 
 std::optional<ShiftDirection> parseShiftArg(std::string arg) {
 	if (arg == "l" || arg == "left") return ShiftDirection::Left;
@@ -211,6 +222,7 @@ void dispatch_debug(std::string arg) {
 void registerDispatchers() {
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:makegroup", dispatch_makegroup);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changegroup", dispatch_changegroup);
+	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changeephemerality", dispatch_changeephemerality);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:movefocus", dispatch_movefocus);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:movewindow", dispatch_movewindow);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changefocus", dispatch_changefocus);

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -49,21 +49,14 @@ void dispatch_changegroup(std::string value) {
 
 	auto args = CVarList(value);
 
-	GroupEphemeralityOption ephemeral = GroupEphemeralityOption::Standard;
-	if (args[1] == "ephemeral") {
-		ephemeral = GroupEphemeralityOption::Ephemeral;
-	} else if (args[1] == "force_ephemeral") {
-		ephemeral = GroupEphemeralityOption::ForceEphemeral;
-	}
-
 	if (args[0] == "h") {
-		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::SplitH, ephemeral);
+		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::SplitH);
 	} else if (args[0] == "v") {
-		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::SplitV, ephemeral);
+		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::SplitV);
 	} else if (args[0] == "tab") {
-		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::Tabbed, ephemeral);
+		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::Tabbed);
 	} else if (args[0] == "untab") {
-		g_Hy3Layout->untabGroupOnWorkspace(workspace, ephemeral);
+		g_Hy3Layout->untabGroupOnWorkspace(workspace);
 	}
 	// TODO
 	//else if (args[0] == "opposite") {

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -62,7 +62,7 @@ void dispatch_changegroup(std::string value) {
 	}
 }
 
-void dispatch_changeephemerality(std::string value) {
+void dispatch_setephemeral(std::string value) {
 	int workspace = workspace_for_action();
 	if (workspace == -1) return;
 
@@ -219,7 +219,7 @@ void dispatch_debug(std::string arg) {
 void registerDispatchers() {
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:makegroup", dispatch_makegroup);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changegroup", dispatch_changegroup);
-	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changeephemerality", dispatch_changeephemerality);
+	HyprlandAPI::addDispatcher(PHANDLE, "hy3:setephemeral", dispatch_setephemeral);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:movefocus", dispatch_movefocus);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:movewindow", dispatch_movewindow);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changefocus", dispatch_changefocus);

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -57,11 +57,9 @@ void dispatch_changegroup(std::string value) {
 		g_Hy3Layout->changeGroupOnWorkspace(workspace, Hy3GroupLayout::Tabbed);
 	} else if (args[0] == "untab") {
 		g_Hy3Layout->untabGroupOnWorkspace(workspace);
+	} else if (args[0] == "opposite") {
+		g_Hy3Layout->changeGroupToOppositeOnWorkspace(workspace);
 	}
-	// TODO
-	//else if (args[0] == "opposite") {
-	//	g_Hy3Layout->makeOppositeGroupOnWorkspace(workspace, ephemeral);
-	//}
 }
 
 void dispatch_changeephemerality(std::string value) {


### PR DESCRIPTION
This allows changing the current group a node belongs to, (or creates a new group if it doesn't already exist in one).

This is primarily to support i3's like toggling between a tabbed group and non-tabbed group, but also allows switching non-tabbed layout.

* [x] Allow switching to specifically a horizontal, vertical or tabbed group
* [x] Allow untabbing a group to return to previous non-tabbed layout
* [x] Allow toggling non tab layout between orientations via "opposite"