### PR TITLE
Fix special workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ plugin {
     # offset from group split direction when only one window is in a group
     group_inset = <int> # default: 10
 
+    # scale factor of windows on the special workspace
+    special_scale_factor = <float> # default: 0.8
+
     # tab group settings
     tabs {
       # height of the tab bar

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -8,8 +8,9 @@
 
 int workspace_for_action() {
 	if (g_pLayoutManager->getCurrentLayout() != g_Hy3Layout.get()) return -1;
-
-	int workspace_id = g_pCompositor->m_pLastMonitor->activeWorkspace;
+	int specialWorkspaceID = g_pCompositor->m_pLastMonitor->specialWorkspaceID;
+	int workspace_id
+	    = specialWorkspaceID ? specialWorkspaceID : g_pCompositor->m_pLastMonitor->activeWorkspace;
 
 	if (workspace_id == -1) return -1;
 	auto* workspace = g_pCompositor->getWorkspaceByID(workspace_id);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("no_gaps_when_only", int, 0);
 	CONF("node_collapse_policy", int, 2);
 	CONF("group_inset", int, 10);
+	CONF("special_scale_factor", float, 0.8);
 
 	// tabs
 	CONF("tabs:height", int, 15);


### PR DESCRIPTION
Fixes #18 , and fixes up operation of special workspaces in general. It now operates exactly how it does for any of the non-plugin layouts now. 

I added the `special_scale_factor` config option, which is also present in the other non-plugin layouts, so the scaling factor for special workspaces can be modified.

Have a look over, and hopefully its good to go!