### PR TITLE
Make hy3:no_gaps_when_only affect maximized windows

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1427,7 +1427,7 @@ void Hy3Layout::applyNodeDataToWindow(Hy3Node* node, bool no_animation) {
 	              && root_node->data.as_group.children.front()->data.type == Hy3NodeType::Window;
 
 	if (!g_pCompositor->isWorkspaceSpecial(window->m_iWorkspaceID)
-	    && ((*single_window_no_gaps && only_node)
+	    && ((*single_window_no_gaps && (only_node || window->m_bIsFullscreen))
 	        || (window->m_bIsFullscreen
 	            && g_pCompositor->getWorkspaceByID(window->m_iWorkspaceID)->m_efFullscreenMode
 	                   == FULLSCREEN_FULL)))


### PR DESCRIPTION
This keeps hy3 in line with both of Hyprland's builtin layouts' no_gaps_when_only behavior, which removes gaps on maximized windows even if other windows exist in the workspace.