### PR TITLE
allow setting workspaces for autotiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,9 @@ plugin {
       trigger_height = <int> # default: 0
      
       # a space or comma separated list of workspace ids where autotile should be enabled
+      # it's possible to create an exception rule by prefixing the definition with "not:"
+      # workspaces = 1,2 # autotiling will only be enabled on workspaces 1 and 2
+      # workspaces = not:1,2 # autotiling will be enabled on all workspaces except 1 and 2
       workspaces = <string> # default: all
      
       # if enabled only workspaces that are not in the list are autotiled

--- a/README.md
+++ b/README.md
@@ -212,9 +212,6 @@ plugin {
       # workspaces = 1,2 # autotiling will only be enabled on workspaces 1 and 2
       # workspaces = not:1,2 # autotiling will be enabled on all workspaces except 1 and 2
       workspaces = <string> # default: all
-     
-      # if enabled only workspaces that are not in the list are autotiled
-      workspaces.except = <bool> # default: false
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ plugin {
       # 0 = always automatically split horizontally
       # <number> = pixel height to split at
       trigger_height = <int> # default: 0
+     
+      # a space or comma separated list of workspace ids where autotile should be enabled
+      workspaces = <string> # default: all
+     
+      # if enabled only workspaces that are not in the list are autotiled
+      workspaces.except = <bool> # default: false
     }
   }
 }

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1751,5 +1751,12 @@ void Hy3Layout::updateAtWorkspaces() {
 }
 
 bool Hy3Layout::shouldAtWorkspace(int workspace_id) {
-	return this->at_workspaces.empty() || this->at_workspaces.contains(workspace_id);
+	static const auto* at_workspaces_except
+	    = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:workspaces.except")->intValue;
+
+	if (*at_workspaces_except) {
+		return !this->at_workspaces.empty() && !this->at_workspaces.contains(workspace_id);
+	} else {
+		return this->at_workspaces.empty() || this->at_workspaces.contains(workspace_id);
+	}
 }

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1,7 +1,7 @@
-#include <regex>
-#include <set>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
+#include <regex>
+#include <set>
 
 #include "globals.hpp"
 #include "Hy3Layout.hpp"
@@ -15,30 +15,6 @@ std::unique_ptr<HOOK_CALLBACK_FN> urgentHookPtr
     = std::make_unique<HOOK_CALLBACK_FN>(Hy3Layout::windowGroupUrgentHook);
 std::unique_ptr<HOOK_CALLBACK_FN> tickHookPtr
     = std::make_unique<HOOK_CALLBACK_FN>(Hy3Layout::tickHook);
-
-std::set<int> getAutotileWorkspaces() {
-	std::set<int> workspaces;
-	auto at_workspaces = HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:workspaces")->strValue;
-
-	if (at_workspaces == "all") {
-		return workspaces;
-	}
-
-	// split on space and comma
-	const std::regex regex { R"([\s,]+)" };
-	const auto begin = std::regex_token_iterator(at_workspaces.begin(), at_workspaces.end(), regex, -1);
-	const auto end = std::regex_token_iterator<std::string::iterator>();
-
-    for (auto s = begin; s != end; ++s) {
-        try {
-			workspaces.insert(std::stoi(*s));
-        } catch (...) {
-			hy3_log(ERR, "autotile:workspaces: invalid workspace id: {}", (std::string) *s);
-        }
-    }
-
-	return workspaces;
-}
 
 bool performContainment(Hy3Node& node, bool contained, CWindow* window) {
 	if (node.data.type == Hy3NodeType::Group) {
@@ -189,13 +165,14 @@ void Hy3Layout::onWindowCreatedTiling(CWindow* window) {
 		static const auto* at_ephemeral = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:ephemeral_groups")->intValue;
 		static const auto* at_trigger_width = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:trigger_width")->intValue;
 		static const auto* at_trigger_height = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:trigger_height")->intValue;
-		static const auto at_workspaces = getAutotileWorkspaces();
 		// clang-format on
+
+		this->updateAtWorkspaces();
 
 		auto& target_group = opening_into->data.as_group;
 		if (*at_enable && opening_after != nullptr && target_group.children.size() > 1
-		    && target_group.layout != Hy3GroupLayout::Tabbed &&
-			(at_workspaces.empty() || at_workspaces.contains(opening_into->workspace_id)))
+		    && target_group.layout != Hy3GroupLayout::Tabbed
+		    && this->shouldAtWorkspace(opening_into->workspace_id))
 		{
 			auto is_horizontal = target_group.layout == Hy3GroupLayout::SplitH;
 			auto trigger = is_horizontal ? *at_trigger_width : *at_trigger_height;
@@ -1737,4 +1714,42 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 	}
 
 	return nullptr;
+}
+
+void Hy3Layout::updateAtWorkspaces() {
+	static const auto* at_raw_workspaces
+	    = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:workspaces")->strValue;
+
+	if (*at_raw_workspaces == this->at_raw_workspaces) {
+		return;
+	}
+
+	this->at_raw_workspaces = *at_raw_workspaces;
+	this->at_workspaces.clear();
+
+	if (this->at_raw_workspaces == "all") {
+		return;
+	}
+
+	// split on space and comma
+	const std::regex regex {R"([\s,]+)"};
+	const auto begin = std::regex_token_iterator(
+	    this->at_raw_workspaces.begin(),
+	    this->at_raw_workspaces.end(),
+	    regex,
+	    -1
+	);
+	const auto end = std::regex_token_iterator<std::string::iterator>();
+
+	for (auto s = begin; s != end; ++s) {
+		try {
+			this->at_workspaces.insert(std::stoi(*s));
+		} catch (...) {
+			hy3_log(ERR, "autotile:workspaces: invalid workspace id: {}", (std::string) *s);
+		}
+	}
+}
+
+bool Hy3Layout::shouldAtWorkspace(int workspace_id) {
+	return this->at_workspaces.empty() || this->at_workspaces.contains(workspace_id);
 }

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1717,31 +1717,31 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 }
 
 void Hy3Layout::updateAutotileWorkspaces() {
-	static const auto* at_raw_workspaces
+	static const auto* autotile_raw_workspaces
 	    = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:workspaces")->strValue;
 
-	if (*at_raw_workspaces == this->at_raw_workspaces) {
+	if (*autotile_raw_workspaces == this->autotile.raw_workspaces) {
 		return;
 	}
 
-	this->at_raw_workspaces = *at_raw_workspaces;
-	this->at_workspaces.clear();
+	this->autotile.raw_workspaces = *autotile_raw_workspaces;
+	this->autotile.workspaces.clear();
 
-	if (this->at_raw_workspaces == "all") {
+	if (this->autotile.raw_workspaces == "all") {
 		return;
 	}
 
-	this->at_workspaces_blacklist = this->at_raw_workspaces.rfind("not:", 0) == 0;
+	this->autotile.workspace_blacklist = this->autotile.raw_workspaces.rfind("not:", 0) == 0;
 
-	const auto at_raw_workspaces_filtered = (this->at_workspaces_blacklist)
-	                                          ? this->at_raw_workspaces.substr(4)
-	                                          : this->at_raw_workspaces;
+	const auto autotile_raw_workspaces_filtered = (this->autotile.workspace_blacklist)
+	                                                ? this->autotile.raw_workspaces.substr(4)
+	                                                : this->autotile.raw_workspaces;
 
 	// split on space and comma
 	const std::regex regex {R"([\s,]+)"};
 	const auto begin = std::sregex_token_iterator(
-	    at_raw_workspaces_filtered.begin(),
-	    at_raw_workspaces_filtered.end(),
+	    autotile_raw_workspaces_filtered.begin(),
+	    autotile_raw_workspaces_filtered.end(),
 	    regex,
 	    -1
 	);
@@ -1749,7 +1749,7 @@ void Hy3Layout::updateAutotileWorkspaces() {
 
 	for (auto s = begin; s != end; ++s) {
 		try {
-			this->at_workspaces.insert(std::stoi(*s));
+			this->autotile.workspaces.insert(std::stoi(*s));
 		} catch (...) {
 			hy3_log(ERR, "autotile:workspaces: invalid workspace id: {}", (std::string) *s);
 		}
@@ -1757,9 +1757,9 @@ void Hy3Layout::updateAutotileWorkspaces() {
 }
 
 bool Hy3Layout::shouldAutotileWorkspace(int workspace_id) {
-	if (this->at_workspaces_blacklist) {
-		return !this->at_workspaces.contains(workspace_id);
+	if (this->autotile.workspace_blacklist) {
+		return !this->autotile.workspaces.contains(workspace_id);
 	} else {
-		return this->at_workspaces.empty() || this->at_workspaces.contains(workspace_id);
+		return this->autotile.workspaces.empty() || this->autotile.workspaces.contains(workspace_id);
 	}
 }

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -167,12 +167,12 @@ void Hy3Layout::onWindowCreatedTiling(CWindow* window) {
 		static const auto* at_trigger_height = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:trigger_height")->intValue;
 		// clang-format on
 
-		this->updateAtWorkspaces();
+		this->updateAutotileWorkspaces();
 
 		auto& target_group = opening_into->data.as_group;
 		if (*at_enable && opening_after != nullptr && target_group.children.size() > 1
 		    && target_group.layout != Hy3GroupLayout::Tabbed
-		    && this->shouldAtWorkspace(opening_into->workspace_id))
+		    && this->shouldAutotileWorkspace(opening_into->workspace_id))
 		{
 			auto is_horizontal = target_group.layout == Hy3GroupLayout::SplitH;
 			auto trigger = is_horizontal ? *at_trigger_width : *at_trigger_height;
@@ -1716,7 +1716,7 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 	return nullptr;
 }
 
-void Hy3Layout::updateAtWorkspaces() {
+void Hy3Layout::updateAutotileWorkspaces() {
 	static const auto* at_raw_workspaces
 	    = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:workspaces")->strValue;
 
@@ -1756,7 +1756,7 @@ void Hy3Layout::updateAtWorkspaces() {
 	}
 }
 
-bool Hy3Layout::shouldAtWorkspace(int workspace_id) {
+bool Hy3Layout::shouldAutotileWorkspace(int workspace_id) {
 	if (this->at_workspaces_blacklist) {
 		return !this->at_workspaces.contains(workspace_id);
 	} else {

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1731,15 +1731,21 @@ void Hy3Layout::updateAtWorkspaces() {
 		return;
 	}
 
+	this->at_workspaces_blacklist = this->at_raw_workspaces.rfind("not:", 0) == 0;
+
+	const auto at_raw_workspaces_filtered = (this->at_workspaces_blacklist)
+	                                          ? this->at_raw_workspaces.substr(4)
+	                                          : this->at_raw_workspaces;
+
 	// split on space and comma
 	const std::regex regex {R"([\s,]+)"};
-	const auto begin = std::regex_token_iterator(
-	    this->at_raw_workspaces.begin(),
-	    this->at_raw_workspaces.end(),
+	const auto begin = std::sregex_token_iterator(
+	    at_raw_workspaces_filtered.begin(),
+	    at_raw_workspaces_filtered.end(),
 	    regex,
 	    -1
 	);
-	const auto end = std::regex_token_iterator<std::string::iterator>();
+	const auto end = std::sregex_token_iterator();
 
 	for (auto s = begin; s != end; ++s) {
 		try {
@@ -1751,11 +1757,8 @@ void Hy3Layout::updateAtWorkspaces() {
 }
 
 bool Hy3Layout::shouldAtWorkspace(int workspace_id) {
-	static const auto* at_workspaces_except
-	    = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:autotile:workspaces.except")->intValue;
-
-	if (*at_workspaces_except) {
-		return !this->at_workspaces.empty() && !this->at_workspaces.contains(workspace_id);
+	if (this->at_workspaces_blacklist) {
+		return !this->at_workspaces.contains(workspace_id);
 	} else {
 		return this->at_workspaces.empty() || this->at_workspaces.contains(workspace_id);
 	}

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -143,6 +143,7 @@ private:
 	bool shouldAtWorkspace(int);
 
 	std::string at_raw_workspaces;
+	bool at_workspaces_blacklist;
 	std::set<int> at_workspaces;
 
 	friend struct Hy3Node;

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -139,8 +139,8 @@ private:
 	// nullptr. if once is true, only one group will be broken out of / into
 	Hy3Node* shiftOrGetFocus(Hy3Node&, ShiftDirection, bool shift, bool once, bool visible);
 
-	void updateAtWorkspaces();
-	bool shouldAtWorkspace(int);
+	void updateAutotileWorkspaces();
+	bool shouldAutotileWorkspace(int);
 
 	std::string at_raw_workspaces;
 	bool at_workspaces_blacklist;

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -9,6 +9,7 @@ enum class GroupEphemeralityOption {
 };
 
 #include <list>
+#include <set>
 
 #include <hyprland/src/layout/IHyprLayout.hpp>
 
@@ -137,6 +138,12 @@ private:
 	// nullptr, if shift is false, return the window in the given direction or
 	// nullptr. if once is true, only one group will be broken out of / into
 	Hy3Node* shiftOrGetFocus(Hy3Node&, ShiftDirection, bool shift, bool once, bool visible);
+
+	void updateAtWorkspaces();
+	bool shouldAtWorkspace(int);
+
+	std::string at_raw_workspaces;
+	std::set<int> at_workspaces;
 
 	friend struct Hy3Node;
 };

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -142,9 +142,11 @@ private:
 	void updateAutotileWorkspaces();
 	bool shouldAutotileWorkspace(int);
 
-	std::string at_raw_workspaces;
-	bool at_workspaces_blacklist;
-	std::set<int> at_workspaces;
+	struct {
+		std::string raw_workspaces;
+		bool workspace_blacklist;
+		std::set<int> workspaces;
+	} autotile;
 
 	friend struct Hy3Node;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -43,6 +43,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("autotile:ephemeral_groups", int, 1);
 	CONF("autotile:trigger_height", int, 0);
 	CONF("autotile:trigger_width", int, 0);
+	CONF("autotile:workspaces", str, "all");
 
 #undef CONF
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,7 +44,6 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("autotile:trigger_height", int, 0);
 	CONF("autotile:trigger_width", int, 0);
 	CONF("autotile:workspaces", str, "all");
-	CONF("autotile:workspaces.except", int, 0);
 
 #undef CONF
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -44,6 +44,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("autotile:trigger_height", int, 0);
 	CONF("autotile:trigger_width", int, 0);
 	CONF("autotile:workspaces", str, "all");
+	CONF("autotile:workspaces.except", int, 0);
 
 #undef CONF
 


### PR DESCRIPTION
Add a new configuration `autotile:workspaces` that allows passing a space/comma separated list of workspace ids where autotiling should be enabled (defaults to `all`).

(Sorry if the code isn't nice, I'm not a C++ developer 😬)