### PR TITLE
Fully implement `resizeactivewindow` dispatcher for tiled and floating windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 compile_commands.json
+.vscode/
+*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Changelog
 
-- Implement `resizeactivewindow` for floating windows
-- Fully implement `resizeactivewindow` for tiled windows
-
 ## Upcoming
 
 - Fixed `hy3:killactive` and `hy3:movetoworkspace` not working in fullscreen.
 - `hy3:movetoworkspace` added to move a whole node to a workspace.
 - Newly tiled windows (usually from moving a window to a new workspace) are now
 placed relative to the last selected node.
+- Implement `resizeactivewindow` for floating windows
+- Fully implement `resizeactivewindow` for tiled windows
 
 ## hl0.34.0 and before
 *check commit history*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+- Implement `resizeactivewindow` for floating windows
+- Fully implement `resizeactivewindow` for tiled windows
+
 ## Upcoming
 
 - Fixed `hy3:killactive` and `hy3:movetoworkspace` not working in fullscreen.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(hy3 SHARED
 )
 
 option(HY3_NO_VERSION_CHECK "Disable hyprland version check" FALSE)
-option(HY3_ENABLE_UNUSED_BLOCKS "Enable the compilation of unused blocks" FALSE)
 
 if (HY3_NO_VERSION_CHECK)
 	target_compile_definitions(hy3 PRIVATE -DHY3_NO_VERSION_CHECK=TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(hy3 SHARED
 )
 
 option(HY3_NO_VERSION_CHECK "Disable hyprland version check" FALSE)
+option(HY3_ENABLE_UNUSED_BLOCKS "Enable the compilation of unused blocks" FALSE)
 
 if (HY3_NO_VERSION_CHECK)
 	target_compile_definitions(hy3 PRIVATE -DHY3_NO_VERSION_CHECK=TRUE)

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -426,8 +426,13 @@ void Hy3Layout::resizeActiveWindow(const Vector2D& delta, eRectCorner corner, CW
 		);
 
 		Vector2D resize_delta = delta;
-		if (display_left && display_right) resize_delta.x = 0;
-		if (display_top && display_bottom) resize_delta.y = 0;
+		bool node_is_root = (node->data.type == Hy3NodeType::Group && node->parent == nullptr)
+			|| (node->data.type == Hy3NodeType::Window && (node->parent == nullptr || node->parent->parent == nullptr));
+
+		if(node_is_root) {
+			if (display_left && display_right) resize_delta.x = 0;
+			if (display_top && display_bottom) resize_delta.y = 0;
+		}
 
 		// Don't execute the logic unless there's something to do
 		if(resize_delta.x != 0 || resize_delta.y != 0) {

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -429,44 +429,47 @@ void Hy3Layout::resizeActiveWindow(const Vector2D& delta, eRectCorner corner, CW
 		if (display_left && display_right) resize_delta.x = 0;
 		if (display_top && display_bottom) resize_delta.y = 0;
 
-		ShiftDirection target_edge_x;
-		ShiftDirection target_edge_y;
+		// Don't execute the logic unless there's something to do
+		if(resize_delta.x != 0 || resize_delta.y != 0) {
+			ShiftDirection target_edge_x;
+			ShiftDirection target_edge_y;
 
-		// Determine the direction in which we're going to look for the neighbor node
-		// that will be resized
-		if(corner == CORNER_NONE) {			// It's probably a keyboard event.
-			target_edge_x = display_right ? ShiftDirection::Left : ShiftDirection::Right;
-			target_edge_y = display_bottom ? ShiftDirection::Up : ShiftDirection::Down;
+			// Determine the direction in which we're going to look for the neighbor node
+			// that will be resized
+			if(corner == CORNER_NONE) {			// It's probably a keyboard event.
+				target_edge_x = display_right ? ShiftDirection::Left : ShiftDirection::Right;
+				target_edge_y = display_bottom ? ShiftDirection::Up : ShiftDirection::Down;
 
-			// If the anchor is not at the top/left then reverse the delta
-			if(target_edge_x == ShiftDirection::Left) resize_delta.x = -resize_delta.x;
-			if(target_edge_y == ShiftDirection::Up) resize_delta.y = -resize_delta.y;
-		} else {							// It's probably a mouse event
-			// Resize against the edges corresponding to the selected corner
-			target_edge_x = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT
-				? ShiftDirection::Left : ShiftDirection::Right;
-			target_edge_y = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT
-				? ShiftDirection::Up : ShiftDirection::Down;
-		}
+				// If the anchor is not at the top/left then reverse the delta
+				if(target_edge_x == ShiftDirection::Left) resize_delta.x = -resize_delta.x;
+				if(target_edge_y == ShiftDirection::Up) resize_delta.y = -resize_delta.y;
+			} else {							// It's probably a mouse event
+				// Resize against the edges corresponding to the selected corner
+				target_edge_x = corner == CORNER_TOPLEFT || corner == CORNER_BOTTOMLEFT
+					? ShiftDirection::Left : ShiftDirection::Right;
+				target_edge_y = corner == CORNER_TOPLEFT || corner == CORNER_TOPRIGHT
+					? ShiftDirection::Up : ShiftDirection::Down;
+			}
 
-		// Find the neighboring node in each axis, which will be either above or at the
-		// same level as the initiating node in the layout hierarchy.  These are the nodes
-		// which must get resized (rather than the initiator) because they are the
-		// highest point in the hierarchy
-		auto horizontal_neighbor = node->findNeighbor(target_edge_x);
-		auto vertical_neighbor = node->findNeighbor(target_edge_y);
+			// Find the neighboring node in each axis, which will be either above or at the
+			// same level as the initiating node in the layout hierarchy.  These are the nodes
+			// which must get resized (rather than the initiator) because they are the
+			// highest point in the hierarchy
+			auto horizontal_neighbor = node->findNeighbor(target_edge_x);
+			auto vertical_neighbor = node->findNeighbor(target_edge_y);
 
-		const auto animate =
-			&g_pConfigManager->getConfigValuePtr("misc:animate_manual_resizes")->intValue;
+			const auto animate =
+				&g_pConfigManager->getConfigValuePtr("misc:animate_manual_resizes")->intValue;
 
-		// Note that the resize direction is reversed, because from the neighbor's perspective
-		// the edge to be moved is the opposite way round.  However, the delta is still the same.
-		if(horizontal_neighbor) {
-			horizontal_neighbor->resize(reverse(target_edge_x), resize_delta.x, *animate == 0);
-		}
+			// Note that the resize direction is reversed, because from the neighbor's perspective
+			// the edge to be moved is the opposite way round.  However, the delta is still the same.
+			if(horizontal_neighbor) {
+				horizontal_neighbor->resize(reverse(target_edge_x), resize_delta.x, *animate == 0);
+			}
 
-		if(vertical_neighbor) {
-			vertical_neighbor->resize(reverse(target_edge_y), resize_delta.y, *animate == 0);
+			if(vertical_neighbor) {
+				vertical_neighbor->resize(reverse(target_edge_y), resize_delta.y, *animate == 0);
+			}
 		}
 	} else if(window->m_bIsFloating) {
 		// No parent node - is this a floating window?  If so, use the same logic as the `main` layout

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1333,14 +1333,12 @@ fullscreen:
 	window->m_vRealPosition = monitor->vecPosition;
 	window->m_vRealSize = monitor->vecSize;
 	goto fsupdate;
-#ifdef HY3_ENABLE_UNUSED_BLOCKS
-unfullscreen:
-	if (node->data.type != Hy3NodeType::Window) return;
-	window = node->data.as_window;
-	window->m_bIsFullscreen = false;
-	workspace->m_bHasFullscreenWindow = false;
-	goto fsupdate;
-#endif
+// unfullscreen:
+// 	if (node->data.type != Hy3NodeType::Window) return;
+// 	window = node->data.as_window;
+// 	window->m_bIsFullscreen = false;
+// 	workspace->m_bHasFullscreenWindow = false;
+// 	goto fsupdate;
 fsupdate:
 	g_pCompositor->updateWindowAnimatedDecorationValues(window);
 	g_pXWaylandManager->setWindowSize(window, window->m_vRealSize.goalv());

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -752,6 +752,7 @@ CWindow* Hy3Layout::getNextWindowCandidate(CWindow* window) {
 	switch (node->data.type) {
 	case Hy3NodeType::Window: return node->data.as_window;
 	case Hy3NodeType::Group: return nullptr;
+	default: return nullptr;
 	}
 }
 
@@ -1072,7 +1073,7 @@ void Hy3Layout::moveNodeToWorkspace(int origin, std::string wsname, bool follow)
 		);
 
 		Hy3Node* expand_actor = nullptr;
-		auto* parent = node->removeFromParentRecursive(&expand_actor);
+		node->removeFromParentRecursive(&expand_actor);
 		if (expand_actor != nullptr) expand_actor->recalcSizePosRecursive();
 
 		changeNodeWorkspaceRecursive(*node, workspace);
@@ -1402,12 +1403,14 @@ fullscreen:
 	window->m_vRealPosition = monitor->vecPosition;
 	window->m_vRealSize = monitor->vecSize;
 	goto fsupdate;
+#ifdef HY3_ENABLE_UNUSED_BLOCKS
 unfullscreen:
 	if (node->data.type != Hy3NodeType::Window) return;
 	window = node->data.as_window;
 	window->m_bIsFullscreen = false;
 	workspace->m_bHasFullscreenWindow = false;
 	goto fsupdate;
+#endif
 fsupdate:
 	g_pCompositor->updateWindowAnimatedDecorationValues(window);
 	g_pXWaylandManager->setWindowSize(window, window->m_vRealSize.goalv());
@@ -1427,10 +1430,12 @@ bool Hy3Layout::shouldRenderSelected(CWindow* window) {
 
 	switch (focused->data.type) {
 	case Hy3NodeType::Window: return focused->data.as_window == window;
-	case Hy3NodeType::Group:
+	case Hy3NodeType::Group: {
 		auto* node = this->getNodeFromWindow(window);
 		if (node == nullptr) return false;
 		return focused->data.as_group.hasChild(node);
+	}
+	default: return false;
 	}
 }
 

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -20,6 +20,12 @@ enum class ShiftDirection {
 	Right,
 };
 
+enum class Axis {
+	None,
+	Horizontal,
+	Vertical
+};
+
 #include "Hy3Node.hpp"
 #include "TabGroup.hpp"
 

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -13,15 +13,15 @@ enum class GroupEphemeralityOption {
 
 #include <hyprland/src/layout/IHyprLayout.hpp>
 
-#include "Hy3Node.hpp"
-#include "TabGroup.hpp"
-
 enum class ShiftDirection {
 	Left,
 	Up,
 	Down,
 	Right,
 };
+
+#include "Hy3Node.hpp"
+#include "TabGroup.hpp"
 
 enum class FocusShift {
 	Top,
@@ -144,6 +144,7 @@ private:
 
 	void updateAutotileWorkspaces();
 	bool shouldAutotileWorkspace(int);
+	void resizeNode(Hy3Node*, Vector2D, ShiftDirection resize_edge_x, ShiftDirection resize_edge_y);
 
 	struct {
 		std::string raw_workspaces;

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -7,7 +7,7 @@
 #include "Hy3Node.hpp"
 #include "globals.hpp"
 
-const float MIN_WINDOW_SIZE = 20;
+const float MIN_RATIO = 0.0f;
 
 // Hy3GroupData //
 
@@ -945,9 +945,11 @@ void Hy3Node::resize(
 				auto requested_size_ratio = this->size_ratio + ratio_mod;
 				auto requested_neighbor_size_ratio = neighbor->size_ratio -ratio_mod;
 
-				if(requested_size_ratio * parent_size >= MIN_WINDOW_SIZE) {
+				if(requested_size_ratio  >= MIN_RATIO
+					&& requested_neighbor_size_ratio >= MIN_RATIO) {
 					this->size_ratio = requested_size_ratio;
 					neighbor->size_ratio = requested_neighbor_size_ratio;
+
 					parent_node->recalcSizePosRecursive(no_animation);
 				}
 			}

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -174,6 +174,7 @@ CWindow* Hy3Node::bringToTop() {
 		}
 
 		return nullptr;
+	default: return nullptr;
 	}
 }
 
@@ -237,6 +238,7 @@ Hy3Node* Hy3Node::getFocusedNode(bool ignore_group_focus, bool stop_at_expanded)
 			    stop_at_expanded
 			);
 		}
+	default: return nullptr;
 	}
 }
 
@@ -584,6 +586,7 @@ bool Hy3Node::isUrgent() {
 		}
 
 		return false;
+	default: return false;
 	}
 }
 

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -99,9 +99,9 @@ struct Hy3Node {
 	void markFocused();
 	void raiseToTop();
 	Hy3Node* getFocusedNode(bool ignore_group_focus = false, bool stop_at_expanded = false);
-	Hy3Node* findSibling(ShiftDirection);
+	Hy3Node* findNeighbor(ShiftDirection);
 	Hy3Node* getImmediateSibling(ShiftDirection);
-	void resize(double, ShiftDirection);
+	void resize(ShiftDirection, double, bool no_animation = false);
 	bool isIndirectlyFocused();
 	Hy3Node& getExpandActor();
 

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -99,7 +99,9 @@ struct Hy3Node {
 	void markFocused();
 	void raiseToTop();
 	Hy3Node* getFocusedNode(bool ignore_group_focus = false, bool stop_at_expanded = false);
-	Hy3Node* findSibling(Hy3GroupLayout inner_layout, ShiftDirection direction_x, ShiftDirection direction_y);
+	Hy3Node* findSibling(ShiftDirection);
+	Hy3Node* getImmediateSibling(ShiftDirection);
+	void resize(double, ShiftDirection);
 	bool isIndirectlyFocused();
 	Hy3Node& getExpandActor();
 

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 struct Hy3Node;
+struct Hy3GroupData;
 enum class Hy3GroupLayout;
 
 #include <list>
@@ -98,6 +99,7 @@ struct Hy3Node {
 	void markFocused();
 	void raiseToTop();
 	Hy3Node* getFocusedNode(bool ignore_group_focus = false, bool stop_at_expanded = false);
+	Hy3Node* findSibling(Hy3GroupLayout inner_layout, ShiftDirection direction_x, ShiftDirection direction_y);
 	bool isIndirectlyFocused();
 	Hy3Node& getExpandActor();
 


### PR DESCRIPTION
### Overview
The `resizeactivewindow` implementation in v0.34.0 was incomplete and only allowed tiled windows to be grown, not shrunk.  It was possible to workaround this by changing focus to a sibling node and then growing _that_ node, but this is clunky and inefficient.  This PR provides the missing functionality so that the `resizeactivewindow` dispatcher works similarly to the `dwindle` layout and `i3`/`sway`.  It also implements `resizeactivewindow` for floating windows, using the same logic as the `master` layer.

### Trivia:
- Ignore `.vscode` directory and all log files
- Remove `gcc` warnings by
  - Adding `default` cases with explicit returns as required (shouldn't be triggered unless the enum parameter was invalid anyway)
  - Surround a code block reached via an unused label with a `#ifdef` and provide `cmake` option

### Changes:
- Add logic to determine the edge which should be moved [resized] based on current node position as well as requested delta
- Factor-out `Hy3Node` tree walk (which was repeated in several places in `Hy3Layout.cpp`) into `Hy3Node` member `findSibling`
- Factor-out `Hy3Node` resize logic into utility function in `Hy3Layout`, re-use for both inner- and outer- nodes
- Minor refactoring of `Hy3Layout::resizeActiveWindow` to use nested if blocks as guards instead of having multiple returns, which I find easier to comprehend when reading the code