### PR TITLE
Multiple keyboard-based focus/resize improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ build/
 compile_commands.json
 .vscode/
 *.log
+.env
+.env.*

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@ build/
 compile_commands.json
 .vscode/
 *.log
-.env
-.env.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Implement `resizeactivewindow` for floating windows
 - Fully implement `resizeactivewindow` for tiled windows
-- Add `hy3:resizenode` dispatcher, drop-in replacement for `resizeactivewindow` applied at the Hy3 group level.
+- `hy3:resizenode` added, drop-in replacement for `resizeactivewindow` applied to a whole node.
 - Implement keyboard-based focusing for floating windows
 - Implement keyboard-based movement for floating windows
   - Add configuration `kbd_shift_delta` providing delta [in pixels] for shift

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 - Implement `resizeactivewindow` for floating windows
 - Fully implement `resizeactivewindow` for tiled windows
-
+- Add `hy3:resizenode` dispatcher, drop-in replacement for `resizeactivewindow` applied at the Hy3 group level.
+- Implement keyboard-based focusing for floating windows
+- Implement keyboard-based movement for floating windows
+  - Add configuration `kbd_shift_delta` providing delta [in pixels] for shift
 ## hl0.35.0 and before
 
 - Fixed `hy3:killactive` and `hy3:movetoworkspace` not working in fullscreen.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ pkg_check_modules(DEPS REQUIRED hyprland pixman-1 libdrm pango pangocairo)
 add_library(hy3 SHARED
 	src/main.cpp
 	src/dispatchers.cpp
+	src/conversions.cpp
 	src/Hy3Layout.cpp
 	src/Hy3Node.cpp
 	src/TabGroup.cpp

--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ plugin {
    - `require_hovered` - affect the tab group under the mouse. do nothing if none are hovered.
    - `wrap` - wrap to the opposite size of the tab bar if moving off the end
  - `hy3:debugnodes` - print the node tree into the hyprland log
+ - `hy3:resizenode, <vector>` - like Hyprland `resizeactive`, but applied to the whole focused group instead of just a window
  - :warning: **ALPHA QUALITY** `hy3:setswallow, <true | false | toggle>` - set the containing node's window swallow state
  - :warning: **ALPHA QUALITY** `hy3:expand, <expand | shrink | base>` - expand the current node to cover other nodes
    - `expand` - expand by one node

--- a/README.md
+++ b/README.md
@@ -221,6 +221,20 @@ plugin {
     # 2 = keep the nested group only if its parent is a tab group
     node_collapse_policy = <int> # default: 2
 
+    # policy controlling what windows will be focused using `hy3:movefocused`
+    # 0 = focus strictly by layout, don't attempt to skip windows that are obscured by another one
+    # 1 = do not focus windows which are entirely obscured by a floating window
+    # 2 = when `hy3:movefocus` layer is `samelayer` then use focus policy 0 (focus strictly by layout)
+    #     when `hy3:movefocus` layer is `all` then use focus policy 1 (don't focus obscured windows)
+    focus_obscured_windows_policy = <int> # default: 2
+
+    # which layers should be considered when changing focus with `hy3:movefocus`?
+    # samelayer = only focus windows on same layer as the source window (floating or tiled)
+    # all       = choose the closest window irrespective of the layout
+    # tiled     = only choose tiled windows, not especially useful but permitted by parser
+    # floating  = only choose floating windows, not especially useful but permitted by parser
+    default_movefocus_layer = <string>    # default: `samelayer`
+
     # offset from group split direction when only one window is in a group
     group_inset = <int> # default: 10
 

--- a/src/BitFlag.hpp
+++ b/src/BitFlag.hpp
@@ -1,69 +1,44 @@
-#ifndef BITFLAG
-#define BITFLAG
+#pragma once
 
 template <typename FlagType>
-struct BitFlag
-{
-    int m_FlagValue = 0;
+struct BitFlag {
+	int m_FlagValue = 0;
 
-    BitFlag() = default;
+	BitFlag() = default;
 
-    BitFlag(FlagType flag) {
-        m_FlagValue = (int)flag;
-    }
+	BitFlag(FlagType flag) { m_FlagValue = (int) flag; }
 
-    operator FlagType() const {
-        return static_cast<FlagType>(m_FlagValue);
-    }
+	operator FlagType() const { return static_cast<FlagType>(m_FlagValue); }
 
-    void Set(FlagType flag) {
-        m_FlagValue |= (int)flag;
-    }
+	void Set(FlagType flag) { m_FlagValue |= (int) flag; }
 
-    void Unset(FlagType flag) {
-        m_FlagValue &= ~(int)flag;
-    }
+	void Unset(FlagType flag) { m_FlagValue &= ~(int) flag; }
 
-    void Toggle(FlagType flag) {
-        m_FlagValue ^= (int)flag;
-    }
+	void Toggle(FlagType flag) { m_FlagValue ^= (int) flag; }
 
-    void Mask(FlagType flag) {
-        m_FlagValue &= (int)flag;
-    }
+	void Mask(FlagType flag) { m_FlagValue &= (int) flag; }
 
-    bool Has(FlagType flag) const {
-        return (m_FlagValue & (int)flag) == (int)flag;
-    }
+	bool Has(FlagType flag) const { return (m_FlagValue & (int) flag) == (int) flag; }
 
-    bool HasAny(FlagType flag) const {
-        return (m_FlagValue & (int)flag) != 0;
-    }
-    bool HasNot(FlagType flag) const {
-        return (m_FlagValue & (int)flag) != (int)flag;
-    }
+	bool HasAny(FlagType flag) const { return (m_FlagValue & (int) flag) != 0; }
+	bool HasNot(FlagType flag) const { return (m_FlagValue & (int) flag) != (int) flag; }
 
-    const BitFlag& operator |=(FlagType flag) {
-        Set(flag);
-        return *this;
-    }
+	const BitFlag& operator|=(FlagType flag) {
+		Set(flag);
+		return *this;
+	}
 
-    const BitFlag& operator &=(FlagType flag) {
-        Mask(flag);
-        return *this;
-    }
+	const BitFlag& operator&=(FlagType flag) {
+		Mask(flag);
+		return *this;
+	}
 
-    const BitFlag& operator ^=(FlagType flag) {
-        Toggle(flag);
-        return *this;
-    }
+	const BitFlag& operator^=(FlagType flag) {
+		Toggle(flag);
+		return *this;
+	}
 
-    bool operator==(FlagType flag) const {
-        return m_FlagValue == (int)flag;
-    }
+	bool operator==(FlagType flag) const { return m_FlagValue == (int) flag; }
 
-    bool operator!=(FlagType flag) const {
-        return m_FlagValue != (int)flag;
-    }
+	bool operator!=(FlagType flag) const { return m_FlagValue != (int) flag; }
 };
-#endif

--- a/src/BitFlag.hpp
+++ b/src/BitFlag.hpp
@@ -1,0 +1,69 @@
+#ifndef BITFLAG
+#define BITFLAG
+
+template <typename FlagType>
+struct BitFlag
+{
+    int m_FlagValue = 0;
+
+    BitFlag() = default;
+
+    BitFlag(FlagType flag) {
+        m_FlagValue = (int)flag;
+    }
+
+    operator FlagType() const {
+        return static_cast<FlagType>(m_FlagValue);
+    }
+
+    void Set(FlagType flag) {
+        m_FlagValue |= (int)flag;
+    }
+
+    void Unset(FlagType flag) {
+        m_FlagValue &= ~(int)flag;
+    }
+
+    void Toggle(FlagType flag) {
+        m_FlagValue ^= (int)flag;
+    }
+
+    void Mask(FlagType flag) {
+        m_FlagValue &= (int)flag;
+    }
+
+    bool Has(FlagType flag) const {
+        return (m_FlagValue & (int)flag) == (int)flag;
+    }
+
+    bool HasAny(FlagType flag) const {
+        return (m_FlagValue & (int)flag) != 0;
+    }
+    bool HasNot(FlagType flag) const {
+        return (m_FlagValue & (int)flag) != (int)flag;
+    }
+
+    const BitFlag& operator |=(FlagType flag) {
+        Set(flag);
+        return *this;
+    }
+
+    const BitFlag& operator &=(FlagType flag) {
+        Mask(flag);
+        return *this;
+    }
+
+    const BitFlag& operator ^=(FlagType flag) {
+        Toggle(flag);
+        return *this;
+    }
+
+    bool operator==(FlagType flag) const {
+        return m_FlagValue == (int)flag;
+    }
+
+    bool operator!=(FlagType flag) const {
+        return m_FlagValue != (int)flag;
+    }
+};
+#endif

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1113,15 +1113,16 @@ CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, BitFlag
 	// If the closest window is on a different monitor and the nearest edge has the same position
 	// as the last focused window on that monitor's workspace then choose the last focused window instead; this
 	// allows seamless back-and-forth by direction keys
-	if(target_window && target_window->m_iWorkspaceID == next_workspace) {
+	if(target_window && target_window->m_iMonitorID != source->m_iMonitorID) {
 		if (auto new_workspace = g_pCompositor->getWorkspaceByID(next_workspace)) {
 			if (auto last_focused = new_workspace->getLastFocusedWindow()) {
 				auto target_bounds = CBox(target_window->m_vRealPosition.vec(), target_window->m_vRealSize.vec());
 				auto last_focused_bounds = CBox(last_focused->m_vRealPosition.vec(), last_focused->m_vRealSize.vec());
-				if((direction == ShiftDirection::Left && target_bounds.x + target_bounds.w == last_focused_bounds.x + last_focused_bounds.w)
-					|| (direction == ShiftDirection::Right && target_bounds.x == last_focused_bounds.x)
-					|| (direction == ShiftDirection::Up && target_bounds.y + target_bounds.h == last_focused_bounds.y + last_focused_bounds.h)
-					|| (direction == ShiftDirection::Down && target_bounds.y == last_focused_bounds.y)) {
+
+				if((direction == ShiftDirection::Left && STICKS(target_bounds.x + target_bounds.w, last_focused_bounds.x + last_focused_bounds.w))
+					|| (direction == ShiftDirection::Right && STICKS(target_bounds.x, last_focused_bounds.x))
+					|| (direction == ShiftDirection::Up && STICKS(target_bounds.y + target_bounds.h, last_focused_bounds.y + last_focused_bounds.h))
+					|| (direction == ShiftDirection::Down && STICKS(target_bounds.y, last_focused_bounds.y))) {
 						target_window = last_focused;
 				}
 			}

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -947,8 +947,7 @@ void shiftFloatingWindow(CWindow* window, ShiftDirection direction) {
 				g_pCompositor->moveWindowToWorkspaceSafe(window, new_workspace);
 				g_pCompositor->setActiveMonitor(new_monitor);
 
-				static auto* const allow_workspace_cycles =
-		    		&HyprlandAPI::getConfigValue(PHANDLE, "binds:allow_workspace_cycles")->intValue;
+				const static auto allow_workspace_cycles = ConfigValue<Hyprlang::INT>("binds:allow_workspace_cycles");
 				if (*allow_workspace_cycles) new_workspace->rememberPrevWorkspace(old_workspace);
 			}
 		} else {
@@ -989,7 +988,7 @@ void Hy3Layout::focusMonitor(CMonitor* monitor) {
 			for (auto& w: g_pCompositor->m_vWindows | std::views::reverse) {
 				if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2
 					&& w->m_iWorkspaceID == next_window->m_iWorkspaceID && !w->m_bX11ShouldntFocus
-					&& !w->m_bNoFocus)
+					&& !w->m_sAdditionalConfigData.noFocus)
 				{
 					next_window = w.get();
 					break;
@@ -1072,8 +1071,8 @@ CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, BitFlag
 	const auto current_surface_box = source->getWindowMainSurfaceBox();
 	auto target_distance = Distance { direction };
 
-	int focus_policy = *ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
-	bool permit_obscured_windows = focus_policy == 0 || (focus_policy == 2 && layers_same_monitor.HasNot(Layer::Floating | Layer::Tiled));
+	const auto static focus_policy = ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
+	bool permit_obscured_windows = *focus_policy == 0 || (*focus_policy == 2 && layers_same_monitor.HasNot(Layer::Floating | Layer::Tiled));
 
 	// TODO: Don't assume that source window is on focused monitor
 	// BUG:  This will only find windows on the immediately neighbouring monitor, it won't find any on
@@ -1090,7 +1089,7 @@ CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, BitFlag
 			&& (monitor_flags.Has(window_layer))
 			&& w->m_bIsMapped
 			&& w->m_iX11Type != 2
-			&& !w->m_bNoFocus
+			&& !w->m_sAdditionalConfigData.noFocus
 			&& !w->isHidden()
 			&& !w->m_bX11ShouldntFocus;
 	};
@@ -1158,8 +1157,8 @@ void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible
 	// If no eligible_layers specified then choose the same layer as the source window
 	if(eligible_layers == Layer::None) eligible_layers = source_window->m_bIsFloating ? Layer::Floating : Layer::Tiled;
 
-	int focus_policy = *ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
-	bool skip_obscured = focus_policy == 1 || (focus_policy == 2 && eligible_layers.Has(Layer::Floating | Layer::Tiled));
+	const auto static focus_policy = ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
+	bool skip_obscured = *focus_policy == 1 || (*focus_policy == 2 && eligible_layers.Has(Layer::Floating | Layer::Tiled));
 
 	// Determine the starting point for looking for a tiled node - it's either the
 	// workspace's focused node or the floating window's focus entry point (which may be null)

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1,6 +1,7 @@
 #include <regex>
 #include <set>
-
+#include <functional>
+#include <numeric>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/plugins/PluginAPI.hpp>
 #include <ranges>
@@ -8,6 +9,7 @@
 #include "Hy3Layout.hpp"
 #include "SelectionHook.hpp"
 #include "globals.hpp"
+#include "conversions.hpp"
 
 std::unique_ptr<HOOK_CALLBACK_FN> renderHookPtr =
     std::make_unique<HOOK_CALLBACK_FN>(Hy3Layout::renderHook);
@@ -169,7 +171,7 @@ void Hy3Layout::insertNode(Hy3Node& node) {
 
 	if (opening_after != nullptr
 	    && ((node.data.type == Hy3NodeType::Group
-	         && (opening_after == &node || node.data.as_group.hasChild(opening_after)))
+	         && (opening_after == &node || node.hasChild(opening_after)))
 	        || opening_after->reparenting))
 	{
 		opening_after = nullptr;
@@ -287,6 +289,7 @@ void Hy3Layout::insertNode(Hy3Node& node) {
 }
 
 void Hy3Layout::onWindowRemovedTiling(CWindow* window) {
+	this->m_focusIntercepts.erase(window);
 	static const auto node_collapse_policy =
 	    ConfigValue<Hyprlang::INT>("plugin:hy3:node_collapse_policy");
 
@@ -342,12 +345,16 @@ void Hy3Layout::onWindowRemovedTiling(CWindow* window) {
 	}
 }
 
+void Hy3Layout::onWindowRemovedFloating(CWindow *window) {
+	this->m_focusIntercepts.erase(window);
+}
+
 void Hy3Layout::onWindowFocusChange(CWindow* window) {
 	auto* node = this->getNodeFromWindow(window);
 	if (node == nullptr) return;
 
 	hy3_log(
-	    TRACE,
+	    LOG,
 	    "changing window focus to window {:x} as node {:x}",
 	    (uintptr_t) window,
 	    (uintptr_t) node
@@ -372,15 +379,9 @@ void Hy3Layout::recalculateMonitor(const int& monitor_id) {
 	// todo: refactor this
 
 	auto* top_node = this->getWorkspaceRootGroup(monitor->activeWorkspace);
-	if (top_node != nullptr) {
-		top_node->position = monitor->vecPosition + monitor->vecReservedTopLeft;
-		top_node->size =
-		    monitor->vecSize - monitor->vecReservedTopLeft - monitor->vecReservedBottomRight;
-
-		top_node->recalcSizePosRecursive();
+	if(top_node == nullptr) {
+		top_node = this->getWorkspaceRootGroup(monitor->specialWorkspaceID);
 	}
-
-	top_node = this->getWorkspaceRootGroup(monitor->specialWorkspaceID);
 
 	if (top_node != nullptr) {
 		top_node->position = monitor->vecPosition + monitor->vecReservedTopLeft;
@@ -480,28 +481,31 @@ void executeResizeOperation(const Vector2D& delta, eRectCorner corner, Hy3Node *
 }
 
 void Hy3Layout::resizeNode(const Vector2D& delta, eRectCorner corner, Hy3Node* node) {
-	if(node == nullptr) return;
-
-	auto monitor = g_pCompositor->getMonitorFromID(g_pCompositor->getWorkspaceByID(node->workspace_id)->m_iMonitorID);
-	executeResizeOperation(delta, corner, node, monitor);
+	// Is the intended target really a node or a floating window?
+	auto window = g_pCompositor->m_pLastWindow;
+	if(window && window->m_bIsFloating) {
+		this->resizeActiveWindow(delta, corner, window);
+	} else if (node) {
+		auto monitor = g_pCompositor->getMonitorFromID(g_pCompositor->getWorkspaceByID(node->workspace_id)->m_iMonitorID);
+		executeResizeOperation(delta, corner, node, monitor);
+	}
 }
 
 void Hy3Layout::resizeActiveWindow(const Vector2D& delta, eRectCorner corner, CWindow* pWindow) {
 	auto window = pWindow ? pWindow : g_pCompositor->m_pLastWindow;
 	if(window == nullptr || ! g_pCompositor->windowValidMapped(window)) return;
 
-	auto* node = this->getNodeFromWindow(window);
-
-	if (node != nullptr) {
-		executeResizeOperation(delta, corner, &node->getExpandActor(), g_pCompositor->getMonitorFromID(window->m_iMonitorID));
-	} else if(window->m_bIsFloating) {
-		// No parent node - is this a floating window?  If so, use the same logic as the `main` layout
+	if (window->m_bIsFloating) {
+		// Use the same logic as the `main` layout for floating windows
 		const auto required_size = Vector2D(
 		    std::max((window->m_vRealSize.goalv() + delta).x, 20.0),
 		    std::max((window->m_vRealSize.goalv() + delta).y, 20.0)
 		);
 		window->m_vRealSize = required_size;
-	}
+		g_pXWaylandManager->setWindowSize(window, required_size);
+	} else if (auto* node = this->getNodeFromWindow(window);node != nullptr) {
+		executeResizeOperation(delta, corner, &node->getExpandActor(), g_pCompositor->getMonitorFromID(window->m_iMonitorID));
+	};
 }
 
 void Hy3Layout::fullscreenRequestForWindow(
@@ -619,16 +623,26 @@ void Hy3Layout::switchWindows(CWindow* pWindowA, CWindow* pWindowB) {
 
 void Hy3Layout::moveWindowTo(CWindow* window, const std::string& direction) {
 	auto* node = this->getNodeFromWindow(window);
-	if (node == nullptr) return;
+	if (node == nullptr) {
+		const auto neighbor = g_pCompositor->getWindowInDirection(window, direction[0]);
 
-	ShiftDirection shift;
-	if (direction == "l") shift = ShiftDirection::Left;
-	else if (direction == "r") shift = ShiftDirection::Right;
-	else if (direction == "u") shift = ShiftDirection::Up;
-	else if (direction == "d") shift = ShiftDirection::Down;
-	else return;
+		if (window->m_iWorkspaceID != neighbor->m_iWorkspaceID) {
+			// if different monitors, send to monitor
+			onWindowRemovedTiling(window);
+			window->moveToWorkspace(neighbor->m_iWorkspaceID);
+			window->m_iMonitorID = neighbor->m_iMonitorID;
+			onWindowCreatedTiling(window);
+		}
+	} else {
+		ShiftDirection shift;
+		if (direction == "l") shift = ShiftDirection::Left;
+		else if (direction == "r") shift = ShiftDirection::Right;
+		else if (direction == "u") shift = ShiftDirection::Up;
+		else if (direction == "d") shift = ShiftDirection::Down;
+		else return;
 
-	this->shiftNode(*node, shift, false, false);
+		this->shiftNode(*node, shift, false, false);
+	}
 }
 
 void Hy3Layout::alterSplitRatio(CWindow* pWindow, float delta, bool exact) {
@@ -878,45 +892,368 @@ void Hy3Layout::shiftNode(Hy3Node& node, ShiftDirection direction, bool once, bo
 	}
 }
 
-void Hy3Layout::shiftWindow(int workspace, ShiftDirection direction, bool once, bool visible) {
-	auto* node = this->getWorkspaceFocusedNode(workspace);
-	if (node == nullptr) return;
+void shiftFloatingWindow(CWindow* window, ShiftDirection direction) {
+	static const auto* kbd_shift_delta =
+	    &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:kbd_shift_delta")->intValue;
 
-	this->shiftNode(*node, direction, once, visible);
-}
+	if(!window) return;
 
-void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible) {
-	auto* current_window = g_pCompositor->m_pLastWindow;
-
-	if (current_window != nullptr) {
-		auto* p_workspace = g_pCompositor->getWorkspaceByID(current_window->m_iWorkspaceID);
-		if (p_workspace->m_bHasFullscreenWindow) return;
-
-		if (current_window->m_bIsFloating) {
-			auto* next_window = g_pCompositor->getWindowInDirection(
-			    current_window,
-			    direction == ShiftDirection::Left   ? 'l'
-			    : direction == ShiftDirection::Up   ? 'u'
-			    : direction == ShiftDirection::Down ? 'd'
-			                                        : 'r'
-			);
-
-			if (next_window != nullptr) g_pCompositor->focusWindow(next_window);
-			return;
+	Vector2D bounds {0, 0};
+	// BUG:  Assumes horizontal monitor layout
+	// BUG:  Ignores monitor reserved space
+	for(auto m: g_pCompositor->m_vMonitors) {
+		bounds.x = std::max(bounds.x, m->vecPosition.x + m->vecSize.x);
+		if(m->ID == window->m_iMonitorID) {
+			bounds.y = m->vecPosition.y + m->vecSize.y;
 		}
 	}
 
-	auto* node = this->getWorkspaceFocusedNode(workspace);
-	if (node == nullptr) return;
+	const int delta = getSearchDirection(direction) == SearchDirection::Forwards
+		? *kbd_shift_delta: -*kbd_shift_delta;
 
-	auto* target = this->shiftOrGetFocus(*node, direction, false, false, visible);
+	Vector2D movement_delta = (getAxis(direction) == Axis::Horizontal)
+		? Vector2D{ delta, 0 } : Vector2D{ 0, delta };
 
-	if (target != nullptr) {
-		target->focus();
-		while (target->parent != nullptr) target = target->parent;
-		target->recalcSizePosRecursive();
+	auto window_pos = window->m_vRealPosition.vec();
+	auto window_size = window->m_vRealSize.vec();
+
+	// Keep at least `delta` pixels visible
+	if (window_pos.x + window_size.x + delta < 0 || window_pos.x + delta > bounds.x) movement_delta.x = 0;
+	if (window_pos.y + window_size.y + delta < 0 || window_pos.y + delta > bounds.y) movement_delta.y = 0;
+	if(movement_delta.x != 0 || movement_delta.y != 0) {
+		auto new_pos = window_pos + movement_delta;
+		// Do we need to change the workspace?
+		const auto new_monitor = g_pCompositor->getMonitorFromVector(new_pos);
+		if(new_monitor && new_monitor->ID != window->m_iMonitorID) {
+			// Ignore the movement request if the new workspace is special
+			if(! new_monitor->specialWorkspaceID) {
+				const auto old_workspace = g_pCompositor->getWorkspaceByID(window->m_iWorkspaceID);
+				const auto new_workspace = g_pCompositor->getWorkspaceByID(new_monitor->activeWorkspace);
+				const auto previous_monitor = g_pCompositor->getMonitorFromID(window->m_iMonitorID);
+				const auto original_new_pos = new_pos;
+
+				if(new_workspace && previous_monitor) {
+					switch (direction)
+					{
+						case ShiftDirection::Left: new_pos.x += new_monitor->vecSize.x; break;
+						case ShiftDirection::Right: new_pos.x -= previous_monitor->vecSize.x; break;
+						case ShiftDirection::Up: new_pos.y += new_monitor->vecSize.y; break;
+						case ShiftDirection::Down: new_pos.y -= previous_monitor->vecSize.y; break;
+						default: UNREACHABLE();
+					}
+				}
+
+				window->m_vRealPosition = new_pos;
+				g_pCompositor->moveWindowToWorkspaceSafe(window, new_workspace);
+				g_pCompositor->setActiveMonitor(new_monitor);
+
+				static auto* const allow_workspace_cycles =
+		    		&g_pConfigManager->getConfigValuePtr("binds:allow_workspace_cycles")->intValue;
+				if (*allow_workspace_cycles) new_workspace->rememberPrevWorkspace(old_workspace);
+			}
+		} else {
+			window->m_vRealPosition = new_pos;
+		}
 	}
 }
+
+void Hy3Layout::shiftWindow(int workspace_id, ShiftDirection direction, bool once, bool visible) {
+	auto focused_window = g_pCompositor->m_pLastWindow;
+	auto* node = getWorkspaceFocusedNode(workspace_id);
+
+	if (focused_window && focused_window->m_bIsFloating) {
+		shiftFloatingWindow(focused_window, direction);
+	} else if (node) {
+		shiftNode(*node, direction, once, visible);
+	}
+}
+
+void Hy3Layout::focusMonitor(CMonitor* monitor) {
+	if(monitor == nullptr) return;
+
+	g_pCompositor->setActiveMonitor(monitor);
+	const auto focusedNode = this->getWorkspaceFocusedNode(monitor->activeWorkspace);
+	if(focusedNode != nullptr) {
+		focusedNode->focus();
+	} else {
+		auto* workspace = g_pCompositor->getWorkspaceByID(monitor->activeWorkspace);
+		CWindow* next_window = nullptr;
+		if(workspace != nullptr) {
+			workspace->setActive(true);
+			if (workspace->m_bHasFullscreenWindow) {
+				next_window = g_pCompositor->getFullscreenWindowOnWorkspace(workspace->m_iID);
+			} else {
+				next_window = workspace->getLastFocusedWindow();
+			}
+		} else {
+			for (auto& w: g_pCompositor->m_vWindows | std::views::reverse) {
+				if (w->m_bIsMapped && !w->isHidden() && w->m_bIsFloating && w->m_iX11Type != 2
+					&& w->m_iWorkspaceID == next_window->m_iWorkspaceID && !w->m_bX11ShouldntFocus
+					&& !w->m_bNoFocus)
+				{
+					next_window = w.get();
+					break;
+				}
+			}
+		}
+		g_pCompositor->focusWindow(next_window);
+	}
+}
+
+CWindow *getFocusedWindow(const Hy3Node *node) {
+	auto search = node;
+	while(search != nullptr && search->data.type == Hy3NodeType::Group) {
+		search = search->data.as_group.focused_child;
+	}
+
+	if(search == nullptr || search->data.type != Hy3NodeType::Window) {
+		return nullptr;
+	}
+
+	return search->data.as_window;
+}
+
+bool shiftIsForward(ShiftDirection direction) {
+	return direction == ShiftDirection::Right || direction == ShiftDirection::Down;
+}
+
+bool shiftIsVertical(ShiftDirection direction) {
+	return direction == ShiftDirection::Up || direction == ShiftDirection::Down;
+}
+
+bool shiftMatchesLayout(Hy3GroupLayout layout, ShiftDirection direction) {
+	return (layout == Hy3GroupLayout::SplitV && shiftIsVertical(direction))
+	    || (layout != Hy3GroupLayout::SplitV && !shiftIsVertical(direction));
+}
+
+
+bool covers(const CBox &outer, const CBox &inner) {
+	return outer.x <= inner.x
+		&& outer.y <= inner.y
+		&& outer.x + outer.w >= inner.x + inner.w
+		&& outer.y + outer.h >= inner.y + inner.h;
+}
+
+bool isObscured (CWindow* window) {
+	if(!window) return false;
+
+	const auto inner_box = window->getWindowMainSurfaceBox();
+
+	bool is_obscured = false;
+	for(auto& w :g_pCompositor->m_vWindows | std::views::reverse) {
+		if(w.get() == window) {
+			hy3_log(LOG, "{} doesn't obscure itself", window);
+			// Don't go any further if this is a floating window, because m_vWindows is sorted bottom->top per Compositor.cpp
+			if(window->m_bIsFloating) break; else continue;
+		}
+
+		if(!w->m_bIsFloating) {
+			hy3_log(LOG, "Tiled window {} can't obscure anything", w.get());
+			continue;
+		}
+
+		const auto outer_box = w->getWindowMainSurfaceBox();
+		is_obscured = covers(outer_box, inner_box);
+
+		if(is_obscured) {
+			hy3_log(LOG, "{} obscures {}", w.get(), window);
+			break;
+		}
+	};
+
+	return is_obscured;
+}
+
+bool isObscured(Hy3Node* node) {
+	return node && node->data.type == Hy3NodeType::Window && isObscured(node->data.as_window);
+}
+
+bool isNotObscured(CWindow* window) { return !isObscured(window); }
+bool isNotObscured(Hy3Node* node) { return !isObscured(node); }
+
+CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, bool considerFloating, bool considerTiled, bool considerOtherMonitors) {
+	if(!source) return nullptr;
+
+	CWindow *target_window = nullptr;
+	const auto current_surface_box = source->getWindowMainSurfaceBox();
+	auto target_distance = Distance { direction };
+
+	auto isCandidate = [=, mon = source->m_iMonitorID](CWindow* w) {
+		return (considerOtherMonitors || w->m_iMonitorID == mon)
+			&& ((considerFloating && w->m_bIsFloating) || (considerTiled && !w->m_bIsFloating) || (w->m_iMonitorID != mon))
+			&& w->m_bIsMapped
+			&& w->m_iX11Type != 2
+			&& !w->m_bNoFocus
+			&& !w->isHidden()
+			&& !w->m_bX11ShouldntFocus;
+	};
+
+	for(auto &pw: g_pCompositor->m_vWindows) {
+		auto w = pw.get();
+		if(w != source && isCandidate(w)) {
+			auto dist = Distance { direction, current_surface_box, w->getWindowMainSurfaceBox() };
+			if((dist < target_distance || (target_distance.isNotInitialised() && dist.isInDirection(direction))) && isNotObscured(w) ) {
+				target_window = w;
+				target_distance = dist;
+			}
+		}
+	}
+
+	hy3_log(LOG, "getWindowInDirection: closest window to {} is {}", source, target_window);
+	return target_window;
+}
+
+void Hy3Layout::shiftFocusToMonitor(ShiftDirection direction) {
+	auto target_monitor = g_pCompositor->getMonitorInDirection(directionToChar(direction));
+	if(target_monitor) this->focusMonitor(target_monitor);
+}
+
+void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible) {
+	Hy3Node    *candidate_node   = nullptr;
+	CWindow    *closest_window   = nullptr;
+	Hy3Node    *source_node      = nullptr;
+	CWindow    *source_window    = g_pCompositor->m_pLastWindow;
+	CWorkspace *source_workspace = g_pCompositor->getWorkspaceByID(workspace);
+
+	if(source_window == nullptr) {
+		shiftFocusToMonitor(direction);
+		return;
+	}
+
+	if(source_workspace == nullptr) return;
+
+	hy3_log(LOG,
+		"shiftFocus: Source: {} ({}), workspace: {}, direction: {}, visible: {}",
+		source_window,
+		source_window->m_bIsFloating ? "floating" : "tiled",
+		workspace,
+		(int)direction,
+		visible
+	);
+
+	// Determine the starting point for looking for a tiled node - it's either the
+	// workspace's focused node or the floating window's focus entry point (which may be null)
+	source_node = source_window->m_bIsFloating ? getFocusOverride(source_window, direction)
+											   : getWorkspaceFocusedNode(workspace);
+
+	// Get the closest node to the starting point
+	if(source_node) {
+		candidate_node = this->shiftOrGetFocus(*source_node, direction, false, false, visible);
+		while(candidate_node && !isNotObscured(candidate_node)) {
+			candidate_node = this->shiftOrGetFocus(*candidate_node, direction, false, false, visible);
+		}
+	}
+
+	bool select_tiled_windows = source_window->m_bIsFloating && !candidate_node;
+
+	// Find the closest window in the right direction.  Only consider tiled windows or other monitors
+	// if `shiftOrGetFocus` didn't provide a candidate.
+	closest_window = getWindowInDirection(source_window, direction, true, select_tiled_windows, !candidate_node);
+
+	// If there's a window in the right direction then choose between that window and the tiled candidate.
+	bool focus_closest_window = false;
+	if(closest_window) {
+		if(candidate_node) {
+			// If the closest window is tiled then focus the tiled node which was obtained from `shiftOrGetFocus`,
+			// otherwise focus whichever is closer
+			if(closest_window->m_bIsFloating) {
+				const auto source_box = source_window->getWindowMainSurfaceBox();
+				Distance distanceToClosestWindow(direction, source_box, closest_window->getWindowMainSurfaceBox());
+				Distance distanceToTiledNode(direction, source_box, candidate_node->getMainSurfaceBox());
+				if(distanceToClosestWindow < distanceToTiledNode) {
+					focus_closest_window = true;
+				}
+			}
+		} else {
+			focus_closest_window = true;
+		}
+	}
+
+	auto new_monitor_id = source_window->m_iMonitorID;
+
+	if(focus_closest_window) {
+		new_monitor_id = closest_window->m_iMonitorID;
+		setFocusOverride(closest_window, direction, source_node);
+		g_pCompositor->focusWindow(closest_window);
+	} else if(candidate_node) {
+		if(candidate_node->data.type == Hy3NodeType::Window) {
+			new_monitor_id = candidate_node->data.as_window->m_iMonitorID;
+		}
+		candidate_node->focusWindow();
+		candidate_node->getRoot()->recalcSizePosRecursive();
+	} else {
+		shiftFocusToMonitor(direction);
+	}
+
+	if(new_monitor_id != source_window->m_iMonitorID) {
+		if(auto *monitor = g_pCompositor->getMonitorFromID(new_monitor_id)) {
+			g_pCompositor->setActiveMonitor(monitor);
+		}
+	}
+}
+
+Hy3Node* Hy3Layout::getFocusOverride(CWindow* src, ShiftDirection direction) {
+	if(auto intercept = this->m_focusIntercepts.find(src); intercept != this->m_focusIntercepts.end()) {
+		hy3_log(LOG, "getFocusOverride: Found intercept for {}", src);
+		Hy3Node** accessor;
+
+		switch (direction)
+		{
+			case ShiftDirection::Left: accessor = &intercept->second.left; break;
+			case ShiftDirection::Up: accessor = &intercept->second.up; break;
+			case ShiftDirection::Right: accessor = &intercept->second.right; break;
+			case ShiftDirection::Down: accessor = &intercept->second.down; break;
+			default: hy3_log(WARN, "Unknown ShiftDirection: {}", (int) direction); return nullptr;
+		}
+
+		if(auto override = *accessor) {
+			// If the root isn't valid or is on a different workspsace then update the intercept data
+			if(override->workspace_id != src->m_iWorkspaceID || !std::ranges::contains(this->nodes, *override)) {
+				override = nullptr;
+				*accessor = nullptr;
+				// If there are no remaining overrides then discard the intercept
+				if(intercept->second.left == nullptr
+					&& intercept->second.up == nullptr
+					&& intercept->second.right == nullptr
+					&& intercept->second.down == nullptr
+				) {
+					this->m_focusIntercepts.erase(intercept);
+				}
+			}
+
+			return override;
+		}
+	}
+
+	hy3_log(LOG, "getFocusOverride: No intercept found for: {}", src);
+	return nullptr;
+}
+
+void Hy3Layout::setFocusOverride(CWindow* src, ShiftDirection direction, Hy3Node* dest) {
+	hy3_log(LOG, "setFocusOverride: Storing intercept for: {} to: {:x}", src, (uintptr_t)dest);
+	if(auto intercept = this->m_focusIntercepts.find(src);intercept != this->m_focusIntercepts.end()) {
+		hy3_log(LOG, "setFocusOverride: Updating existing intercept");
+		switch(direction) {
+			case ShiftDirection::Left: intercept->second.left = dest; break;
+			case ShiftDirection::Up: intercept->second.up = dest; break;
+			case ShiftDirection::Right: intercept->second.right = dest; break;
+			case ShiftDirection::Down: intercept->second.down = dest; break;
+			default: hy3_log(WARN, "Unknown ShiftDirection: {}", (int) direction);
+		}
+	} else {
+		hy3_log(LOG, "setFocusOverride: Adding new intercept");
+		FocusOverride override;
+		switch(direction) {
+			case ShiftDirection::Left: override.left = dest; break;
+			case ShiftDirection::Up: override.up = dest; break;
+			case ShiftDirection::Right: override.right = dest; break;
+			case ShiftDirection::Down: override.down = dest; break;
+			default: hy3_log(WARN, "Unknown ShiftDirection: {}", (int) direction);
+		}
+		this->m_focusIntercepts.insert({ src, override });
+	}
+}
+
 
 void changeNodeWorkspaceRecursive(Hy3Node& node, CWorkspace* workspace) {
 	node.workspace_id = workspace->m_iID;
@@ -1346,7 +1683,7 @@ bool Hy3Layout::shouldRenderSelected(CWindow* window) {
 	case Hy3NodeType::Group: {
 		auto* node = this->getNodeFromWindow(window);
 		if (node == nullptr) return false;
-		return focused->data.as_group.hasChild(node);
+		return focused->hasChild(node);
 	}
 	default: return false;
 	}
@@ -1568,19 +1905,6 @@ void Hy3Layout::applyNodeDataToWindow(Hy3Node* node, bool no_animation) {
 	}
 }
 
-bool shiftIsForward(ShiftDirection direction) {
-	return direction == ShiftDirection::Right || direction == ShiftDirection::Down;
-}
-
-bool shiftIsVertical(ShiftDirection direction) {
-	return direction == ShiftDirection::Up || direction == ShiftDirection::Down;
-}
-
-bool shiftMatchesLayout(Hy3GroupLayout layout, ShiftDirection direction) {
-	return (layout == Hy3GroupLayout::SplitV && shiftIsVertical(direction))
-	    || (layout != Hy3GroupLayout::SplitV && !shiftIsVertical(direction));
-}
-
 Hy3Node* Hy3Layout::shiftOrGetFocus(
     Hy3Node& node,
     ShiftDirection direction,
@@ -1663,10 +1987,14 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 	std::list<Hy3Node*>::iterator insert;
 
 	if (break_origin == parent_group.children.front() && !shiftIsForward(direction)) {
-		if (!shift) return nullptr;
+		if (!shift) {
+			return nullptr;
+		}
 		insert = parent_group.children.begin();
 	} else if (break_origin == parent_group.children.back() && shiftIsForward(direction)) {
-		if (!shift) return nullptr;
+		if (!shift)  {
+			return nullptr;
+		}
 		insert = parent_group.children.end();
 	} else {
 		auto& group_data = target_group->data.as_group;
@@ -1688,14 +2016,18 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 					if (shiftIsForward(direction)) insert = iter;
 					else insert = std::next(iter);
 				}
-			} else return (*iter)->getFocusedNode();
+			} else  {
+				return (*iter)->getFocusedNode();
+			}
 		} else {
 			// break into neighboring groups until we hit a window
 			while (true) {
 				target_group = *iter;
 				auto& group_data = target_group->data.as_group;
 
-				if (group_data.children.empty()) return nullptr; // in theory this would never happen
+				if (group_data.children.empty()) {
+					return nullptr;
+				} // in theory this would never happen
 
 				bool shift_after = false;
 
@@ -1781,7 +2113,7 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 		if (old_parent != nullptr) {
 			auto& group = old_parent->data.as_group;
 			if (old_parent->parent != nullptr && group.ephemeral && group.children.size() == 1
-			    && !group.hasChild(&node))
+			    && !old_parent->hasChild(&node))
 			{
 				Hy3Node::swallowGroups(old_parent);
 			}

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1144,7 +1144,13 @@ void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible
 	CWindow    *source_window    = g_pCompositor->m_pLastWindow;
 	CWorkspace *source_workspace = g_pCompositor->getWorkspaceByID(workspace);
 
-	if(source_window == nullptr || (source_workspace && source_workspace->m_bHasFullscreenWindow)) {
+	if (source_workspace) {
+		source_window = source_workspace->m_pLastFocusedWindow;
+	} else {
+		source_window = g_pCompositor->m_pLastWindow;
+	}
+
+	if (source_window == nullptr || (source_workspace && source_workspace->m_bHasFullscreenWindow)) {
 		shiftFocusToMonitor(direction);
 		return;
 	}

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1068,8 +1068,8 @@ CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, BitFlag
 	if(layers_other_monitors == Layer::None && layers_same_monitor == Layer::None) return nullptr;
 
 	CWindow *target_window = nullptr;
-	const auto current_surface_box = source->getWindowMainSurfaceBox();
-	auto target_distance = Distance { direction };
+	const auto source_middle = source->middle();
+	std::optional<Distance> target_distance;
 
 	const auto static focus_policy = ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
 	bool permit_obscured_windows = *focus_policy == 0 || (*focus_policy == 2 && layers_same_monitor.HasNot(Layer::Floating | Layer::Tiled));
@@ -1097,8 +1097,8 @@ CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, BitFlag
 	for(auto &pw: g_pCompositor->m_vWindows) {
 		auto w = pw.get();
 		if(w != source && isCandidate(w)) {
-			auto dist = Distance { direction, current_surface_box, w->getWindowMainSurfaceBox() };
-			if((dist < target_distance || (target_distance.isNotInitialised() && dist.isInDirection(direction))) && (permit_obscured_windows || isNotObscured(w)) ) {
+			auto dist = Distance { direction, source_middle, w->middle() };
+			if((target_distance.has_value() ? dist < target_distance.value() : dist.isInDirection(direction)) && (permit_obscured_windows || isNotObscured(w)) ) {
 				target_window = w;
 				target_distance = dist;
 			}
@@ -1191,9 +1191,9 @@ void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible
 			// If the closest window is tiled then focus the tiled node which was obtained from `shiftOrGetFocus`,
 			// otherwise focus whichever is closer
 			if(closest_window->m_bIsFloating) {
-				const auto source_box = source_window->getWindowMainSurfaceBox();
-				Distance distanceToClosestWindow(direction, source_box, closest_window->getWindowMainSurfaceBox());
-				Distance distanceToTiledNode(direction, source_box, candidate_node->getMainSurfaceBox());
+				Distance distanceToClosestWindow(direction, source_window->middle(), closest_window->middle());
+				Distance distanceToTiledNode(direction, source_window->middle(), candidate_node->middle());
+
 				if(distanceToClosestWindow < distanceToTiledNode) {
 					focus_closest_window = true;
 				}
@@ -1220,7 +1220,7 @@ void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible
 		shiftFocusToMonitor(direction);
 	}
 
-	if(new_monitor_id.has_value()) {
+	if(new_monitor_id && new_monitor_id.value() != source_window->m_iMonitorID) {
 		if(auto *monitor = g_pCompositor->getMonitorFromID(new_monitor_id.value())) {
 			g_pCompositor->setActiveMonitor(monitor);
 		}

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -894,8 +894,7 @@ void Hy3Layout::shiftNode(Hy3Node& node, ShiftDirection direction, bool once, bo
 }
 
 void shiftFloatingWindow(CWindow* window, ShiftDirection direction) {
-	static const auto* kbd_shift_delta =
-	    &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:kbd_shift_delta")->intValue;
+	static const auto kbd_shift_delta = ConfigValue<Hyprlang::INT>("plugin:hy3:kbd_shift_delta");
 
 	if(!window) return;
 
@@ -1073,7 +1072,7 @@ CWindow* getWindowInDirection(CWindow* source, ShiftDirection direction, BitFlag
 	const auto current_surface_box = source->getWindowMainSurfaceBox();
 	auto target_distance = Distance { direction };
 
-	int focus_policy = *&HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:focus_obscured_windows_policy")->intValue;
+	int focus_policy = *ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
 	bool permit_obscured_windows = focus_policy == 0 || (focus_policy == 2 && layers_same_monitor.HasNot(Layer::Floating | Layer::Tiled));
 
 	// TODO: Don't assume that source window is on focused monitor
@@ -1159,7 +1158,7 @@ void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible
 	// If no eligible_layers specified then choose the same layer as the source window
 	if(eligible_layers == Layer::None) eligible_layers = source_window->m_bIsFloating ? Layer::Floating : Layer::Tiled;
 
-	int focus_policy = *&HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:focus_obscured_windows_policy")->intValue;
+	int focus_policy = *ConfigValue<Hyprlang::INT>("plugin:hy3:focus_obscured_windows_policy");
 	bool skip_obscured = focus_policy == 1 || (focus_policy == 2 && eligible_layers.Has(Layer::Floating | Layer::Tiled));
 
 	// Determine the starting point for looking for a tiled node - it's either the

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -506,7 +506,7 @@ void Hy3Layout::resizeActiveWindow(const Vector2D& delta, eRectCorner corner, CW
 		g_pXWaylandManager->setWindowSize(window, required_size);
 	} else if (auto* node = this->getNodeFromWindow(window);node != nullptr) {
 		executeResizeOperation(delta, corner, &node->getExpandActor(), g_pCompositor->getMonitorFromID(window->m_iMonitorID));
-	};
+	}
 }
 
 void Hy3Layout::fullscreenRequestForWindow(
@@ -2056,8 +2056,9 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 				auto& group_data = target_group->data.as_group;
 
 				if (group_data.children.empty()) {
+					// in theory this would never happen
 					return nullptr;
-				} // in theory this would never happen
+				}
 
 				bool shift_after = false;
 

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1042,23 +1042,16 @@ bool isObscured (CWindow* window) {
 	bool is_obscured = false;
 	for(auto& w :g_pCompositor->m_vWindows | std::views::reverse) {
 		if(w.get() == window) {
-			hy3_log(LOG, "{} doesn't obscure itself", window);
 			// Don't go any further if this is a floating window, because m_vWindows is sorted bottom->top per Compositor.cpp
 			if(window->m_bIsFloating) break; else continue;
 		}
 
-		if(!w->m_bIsFloating) {
-			hy3_log(LOG, "Tiled window {} can't obscure anything", w.get());
-			continue;
-		}
+		if(!w->m_bIsFloating) continue;
 
 		const auto outer_box = w->getWindowMainSurfaceBox();
 		is_obscured = covers(outer_box, inner_box);
 
-		if(is_obscured) {
-			hy3_log(LOG, "{} obscures {}", w.get(), window);
-			break;
-		}
+		if(is_obscured) break;
 	};
 
 	return is_obscured;
@@ -1221,7 +1214,6 @@ void Hy3Layout::shiftFocus(int workspace, ShiftDirection direction, bool visible
 
 Hy3Node* Hy3Layout::getFocusOverride(CWindow* src, ShiftDirection direction) {
 	if(auto intercept = this->m_focusIntercepts.find(src); intercept != this->m_focusIntercepts.end()) {
-		hy3_log(LOG, "getFocusOverride: Found intercept for {}", src);
 		Hy3Node** accessor;
 
 		switch (direction)
@@ -1252,14 +1244,11 @@ Hy3Node* Hy3Layout::getFocusOverride(CWindow* src, ShiftDirection direction) {
 		}
 	}
 
-	hy3_log(LOG, "getFocusOverride: No intercept found for: {}", src);
 	return nullptr;
 }
 
 void Hy3Layout::setFocusOverride(CWindow* src, ShiftDirection direction, Hy3Node* dest) {
-	hy3_log(LOG, "setFocusOverride: Storing intercept for: {} to: {:x}", src, (uintptr_t)dest);
 	if(auto intercept = this->m_focusIntercepts.find(src);intercept != this->m_focusIntercepts.end()) {
-		hy3_log(LOG, "setFocusOverride: Updating existing intercept");
 		switch(direction) {
 			case ShiftDirection::Left: intercept->second.left = dest; break;
 			case ShiftDirection::Up: intercept->second.up = dest; break;
@@ -1268,7 +1257,6 @@ void Hy3Layout::setFocusOverride(CWindow* src, ShiftDirection direction, Hy3Node
 			default: hy3_log(WARN, "Unknown ShiftDirection: {}", (int) direction);
 		}
 	} else {
-		hy3_log(LOG, "setFocusOverride: Adding new intercept");
 		FocusOverride override;
 		switch(direction) {
 			case ShiftDirection::Left: override.left = dest; break;

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -117,6 +117,7 @@ public:
 	void setNodeSwallow(int workspace, SetSwallowOption);
 	void killFocusedNode(int workspace);
 	void expand(int workspace, ExpandOption, ExpandFullscreenOption);
+	void resizeNode(const Vector2D& delta, eRectCorner corner, Hy3Node* node);
 
 	bool shouldRenderSelected(CWindow*);
 
@@ -146,7 +147,6 @@ private:
 
 	void updateAutotileWorkspaces();
 	bool shouldAutotileWorkspace(int);
-	void resizeNode(Hy3Node*, Vector2D, ShiftDirection resize_edge_x, ShiftDirection resize_edge_y);
 
 	struct {
 		std::string raw_workspaces;

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -94,6 +94,20 @@ struct FocusOverride {
 	Hy3Node *up = nullptr;
 	Hy3Node *right = nullptr;
 	Hy3Node *down = nullptr;
+
+	Hy3Node **forDirection(ShiftDirection direction) {
+		switch(direction) {
+			case ShiftDirection::Left: return &left;
+			case ShiftDirection::Up: return &up;
+			case ShiftDirection::Right: return &right;
+			case ShiftDirection::Down: return &down;
+			default: UNREACHABLE();
+		}
+	}
+
+	bool isEmpty() {
+		return !(left || right || up || down);
+	}
 };
 
 

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -4,6 +4,7 @@
 
 #include <hyprland/src/layout/IHyprLayout.hpp>
 #include <map>
+#include "BitFlag.hpp"
 
 class Hy3Layout;
 
@@ -27,6 +28,20 @@ enum class SearchDirection {
 };
 
 enum class Axis { None, Horizontal, Vertical };
+
+enum class Layer {
+	None     = 0,
+	Tiled    = 1 << 0,
+	Floating = 1 << 1
+};
+
+inline Layer operator| (Layer a, Layer b) {
+	return static_cast<Layer>((int)a | (int)b);
+}
+
+inline Layer operator& (Layer a, Layer b) {
+	return static_cast<Layer>((int)a & (int)b);
+}
 
 #include "Hy3Node.hpp"
 #include "TabGroup.hpp"
@@ -125,7 +140,7 @@ public:
 	void changeGroupEphemeralityOn(Hy3Node&, bool ephemeral);
 	void shiftNode(Hy3Node&, ShiftDirection, bool once, bool visible);
 	void shiftWindow(int workspace, ShiftDirection, bool once, bool visible);
-	void shiftFocus(int workspace, ShiftDirection, bool visible);
+	void shiftFocus(int workspace, ShiftDirection, bool visible, BitFlag<Layer> = Layer::None);
 	void moveNodeToWorkspace(int origin, std::string wsname, bool follow);
 	void changeFocus(int workspace, FocusShift);
 	void focusTab(int workspace, TabFocus target, TabFocusMousePriority, bool wrap_scroll, int index);

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -926,6 +926,8 @@ void Hy3Node::resize(ShiftDirection direction, double delta, bool no_animation) 
 					neighbor->size_ratio = requested_neighbor_size_ratio;
 
 					parent_node->recalcSizePosRecursive(no_animation);
+				} else {
+					hy3_log(WARN, "Requested size ratio {} or {} out of bounds, ignoring", requested_size_ratio, requested_neighbor_size_ratio);
 				}
 			}
 		}

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <sstream>
 
 #include <hyprland/src/Compositor.hpp>
@@ -861,8 +862,8 @@ int directionToIteratorIncrement(ShiftDirection direction) {
 	}
 }
 
-CBox Hy3Node::getMainSurfaceBox() {
-	return { this->position, this->size };
+Vector2D Hy3Node::middle() {
+	return this->position + this->size / 2.f;
 }
 
 void Hy3Node::resize(ShiftDirection direction, double delta, bool no_animation) {

--- a/src/conversions.cpp
+++ b/src/conversions.cpp
@@ -1,0 +1,51 @@
+#include "Hy3Node.hpp"
+
+Axis getAxis(Hy3GroupLayout layout) {
+	switch (layout)
+	{
+	case Hy3GroupLayout::SplitH:
+		return Axis::Horizontal;
+	case Hy3GroupLayout::SplitV:
+		return Axis::Vertical;
+	default:
+		return Axis::None;
+	}
+}
+
+Axis getAxis(ShiftDirection direction) {
+	switch (direction)
+	{
+	case ShiftDirection::Left:
+	case ShiftDirection::Right:
+		return Axis::Horizontal;
+	case ShiftDirection::Down:
+	case ShiftDirection::Up:
+		return Axis::Vertical;
+	default:
+		return Axis::None;
+	}
+}
+
+SearchDirection getSearchDirection(ShiftDirection direction) {
+	switch(direction) {
+		case ShiftDirection::Left:
+		case ShiftDirection::Up:
+			return SearchDirection::Backwards;
+		case ShiftDirection::Right:
+		case ShiftDirection::Down:
+			return SearchDirection::Forwards;
+		default:
+			return SearchDirection::None;
+	}
+}
+
+char directionToChar(ShiftDirection direction) {
+	switch (direction)
+	{
+	case ShiftDirection::Left: return 'l';
+	case ShiftDirection::Up: return 'u';
+	case ShiftDirection::Down: return 'd';
+	case ShiftDirection::Right: return 'r';
+	default: return 'r';
+	}
+}

--- a/src/conversions.hpp
+++ b/src/conversions.hpp
@@ -1,0 +1,6 @@
+#include "Hy3Node.hpp"
+
+Axis getAxis(Hy3GroupLayout);
+Axis getAxis(ShiftDirection);
+SearchDirection getSearchDirection(ShiftDirection);
+char directionToChar(ShiftDirection);

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -239,7 +239,7 @@ void dispatch_debug(std::string arg) {
 	if (workspace == -1) return;
 
 	auto* root = g_Hy3Layout->getWorkspaceRootGroup(workspace);
-	if (workspace == -1) {
+	if (root == nullptr) {
 		hy3_log(LOG, "DEBUG NODES: no nodes on workspace");
 	} else {
 		hy3_log(LOG, "DEBUG NODES\n{}", root->debugNode().c_str());

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -130,12 +130,12 @@ void dispatch_movefocus(std::string value) {
 
 		for(auto arg: args) {
 			if(arg == "visible") visible = true;
-			else if ((layerArg = parseLayerArg(arg))) layers = layerArg.value();
+			else if ((layerArg = parseLayerArg(arg))) layers |= layerArg.value();
 		}
 
 		if(!layerArg) {
-			auto default_movefocus_layer = ConfigValue<Hyprlang::STRING>("plugin:hy3:default_movefocus_layer");
-			if((layerArg = parseLayerArg(*default_movefocus_layer))) layers = layerArg.value();
+			const static auto default_movefocus_layer = ConfigValue<Hyprlang::STRING>("plugin:hy3:default_movefocus_layer");
+			if((layerArg = parseLayerArg(*default_movefocus_layer))) layers |= layerArg.value();
 		}
 
 		g_Hy3Layout->shiftFocus(workspace, shift.value(), visible, layers);

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -134,7 +134,7 @@ void dispatch_movefocus(std::string value) {
 		}
 
 		if(!layerArg) {
-			auto default_movefocus_layer = &HyprlandAPI::getConfigValue(PHANDLE, "plugin:hy3:default_movefocus_layer")->strValue;
+			auto default_movefocus_layer = ConfigValue<Hyprlang::STRING>("plugin:hy3:default_movefocus_layer");
 			if((layerArg = parseLayerArg(*default_movefocus_layer))) layers = layerArg.value();
 		}
 

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -8,6 +8,7 @@
 
 int workspace_for_action(bool allow_fullscreen = false) {
 	if (g_pLayoutManager->getCurrentLayout() != g_Hy3Layout.get()) return -1;
+	if(!g_pCompositor->m_pLastMonitor) return -1;
 
 	int workspace_id = g_pCompositor->m_pLastMonitor->activeWorkspace;
 
@@ -245,7 +246,19 @@ void dispatch_debug(std::string arg) {
 	}
 }
 
+void dispatch_resizenode(std::string value) {
+	int workspace = workspace_for_action();
+	if (workspace == -1) return;
+
+	auto* node = g_Hy3Layout->getWorkspaceFocusedNode(workspace, false, true);
+	const auto delta = g_pCompositor->parseWindowVectorArgsRelative(value, Vector2D(0, 0));
+
+	hy3_log(LOG, "resizeNode: node: {:x}, delta: {:X}", (uintptr_t)node, delta);
+	g_Hy3Layout->resizeNode(delta, CORNER_NONE, node);
+}
+
 void registerDispatchers() {
+	HyprlandAPI::addDispatcher(PHANDLE, "hy3:resizenode", dispatch_resizenode);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:makegroup", dispatch_makegroup);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:changegroup", dispatch_changegroup);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:setephemeral", dispatch_setephemeral);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("tab_first_window", INT, 0);
 	CONF("kbd_shift_delta", INT, 20);
 	CONF("default_movefocus_layer", STRING, "samelayer");
-	CONF("focus_obscured_windows", INT, 0);
+	CONF("focus_obscured_windows_policy", INT, 2);
 
 	// tabs
 	CONF("tabs:height", INT, 15);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("node_collapse_policy", INT, 2);
 	CONF("group_inset", INT, 10);
 	CONF("tab_first_window", INT, 0);
+	CONF("kbd_shift_delta", INT, 20);
 
 	// tabs
 	CONF("tabs:height", INT, 15);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,6 +39,8 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("group_inset", INT, 10);
 	CONF("tab_first_window", INT, 0);
 	CONF("kbd_shift_delta", INT, 20);
+	CONF("default_movefocus_layer", STRING, "samelayer");
+	CONF("focus_obscured_windows", INT, 0);
 
 	// tabs
 	CONF("tabs:height", INT, 15);


### PR DESCRIPTION
- Add `hy3:resizenode` dispatcher, which functions just like `resizeactivewindow` but applied to a whole node
- Consider floating windows when handling `hy3:movefocus`
- Consider other monitors when handling `hy3:movefocus` 
- Don't permit direction-based focusing of tiled windows which are completely obscured by a floating window