### PR TITLE
Switched to using the new getWorkspaceRulesFor API fixing #94

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,15 +37,16 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1711673030,
-        "narHash": "sha256-atpS9c2LR56DIURlDLmuKHGmVQj9Xky2aETGhdTwMKg=",
+        "lastModified": 1711996237,
+        "narHash": "sha256-oa82eFINs1HkEnx3Nu+GEQQxXXNkJzSci3HZU//OJ2Y=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "fcd9d77b642c0cd45cae61cf10ed1924f2e7945b",
+        "rev": "3875679755014997776e091ff8903acfb311dd2f",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
+        "ref": "v0.38.0",
         "repo": "Hyprland",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    hyprland.url = "github:hyprwm/Hyprland";
+    hyprland.url = "github:hyprwm/Hyprland?ref=v0.38.0";
   };
 
   outputs = { self, hyprland, ... }: let

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1476,7 +1476,7 @@ void Hy3Layout::applyNodeDataToWindow(Hy3Node* node, bool no_animation) {
 		return;
 	}
 
-	const auto workspace_rule = g_pConfigManager->getWorkspaceRuleFor(workspace);
+	const auto workspace_rules = g_pConfigManager->getWorkspaceRulesFor(workspace);
 
 	// clang-format off
 	static const auto gaps_in = ConfigValue<Hyprlang::CUSTOMTYPE, CCssGapData>("general:gaps_in");
@@ -1513,7 +1513,14 @@ void Hy3Layout::applyNodeDataToWindow(Hy3Node* node, bool no_animation) {
 	            && g_pCompositor->getWorkspaceByID(window->m_iWorkspaceID)->m_efFullscreenMode
 	                   == FULLSCREEN_FULL)))
 	{
-		window->m_sSpecialRenderData.border = workspace_rule.border.value_or(*no_gaps_when_only == 2);
+		window->m_sSpecialRenderData.border = *no_gaps_when_only == 2;
+		for (auto& workspace_rule : workspace_rules) {
+			if (workspace_rule.border.has_value()) {
+				//Hyprland src/desktop/Window.cpp, line 1107, SHA 5e8c25d498ed5cb7852ae74a876b0c138a62d59d
+				//does not break the loop, the last value gets to decide
+				window->m_sSpecialRenderData.border = workspace_rule.border.value();
+			}
+		}
 		window->m_sSpecialRenderData.rounding = false;
 		window->m_sSpecialRenderData.shadow = false;
 


### PR DESCRIPTION
Fix for https://github.com/outfoxxed/hy3/issues/94

This allows hy3 to be compiled with Hyperland:

commit 416b3d6167a996c7e94bd537cec20a12a0784efa (HEAD -> main, origin/main, origin/HEAD)
Author: Vaxry <vaxry@vaxry.net>
Date:   Mon Apr 1 03:54:05 2024 +0100

    socket2: sanitize data for newlines


Notice: I noticed some warnings and errors in the Hyprland logs when using hy3 but I'm quite confident that they are a separate issue and not caused by this patch log output below:


[LOG] Instance Signature: 416b3d6167a996c7e94bd537cec20a12a0784efa_1711989488
[LOG] Hyprland PID: 556698
[LOG] ===== SYSTEM INFO: =====
[LOG] System name: Linux
[LOG] Node name: poseidon
[LOG] Release: 6.7.9-amd64
[LOG] Version: #1 SMP PREEMPT_DYNAMIC Debian 6.7.9-2 (2024-03-13)


[LOG] GPU information:
06:00.0 VGA compatible controller [0300]: Advanced Micro Devices, Inc. [AMD/ATI] Renoir [Radeon RX Vega 6 (Ryzen 4000/5000 Mobile Series)] [1002:1636] (rev d1) (prog-if 00 [VGA controller])


[LOG] os-release:
PRETTY_NAME="Debian GNU/Linux trixie/sid"
NAME="Debian GNU/Linux"
VERSION_CODENAME=trixie
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"

[LOG] ========================



[INFO] If you are crashing, or encounter any bugs, please consult https://wiki.hyprland.org/Crashes-and-Bugs/


[LOG] 
Current splash: "stop playing league loser" - hyprBot


[LOG] Creating the HookSystem!
[LOG] Creating the KeybindManager!
[LOG] [hookSystem] New hook event registered: configReloaded
[LOG] Creating the AnimationManager!
[LOG] Created a bezier curve, baked 255 points, mem usage: 4.08kB, time to bake: 65.37µs. Estimated average calc time: 0.19µs.
[LOG] Creating the ConfigManager!
[LOG] Created a bezier curve, baked 255 points, mem usage: 4.08kB, time to bake: 24.37µs. Estimated average calc time: 0.15µs.
[LOG] Using config: /home/talpa/.config/hypr/hyprland.conf
[LOG] !!!!HEY YOU, YES YOU!!!!: further logs to stdout / logfile are disabled by default. BEFORE SENDING THIS LOG, ENABLE THEM. Use debug:disable_logs = false to do so: https://wiki.hyprland.org/Configuring/Variables/#debug
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[ERR] Invalid dispatcher!
[LOG] Disabling stdout logs! Check the log for further logs.
[LOG] Creating the ThreadManager!
[LOG] Creating CHyprCtl
[LOG] Hypr socket started at /tmp/hypr/416b3d6167a996c7e94bd537cec20a12a0784efa_1711989488/.socket.sock
[LOG] Creating the InputManager!
[LOG] [hookSystem] New hook event registered: keyboardFocus
[LOG] Creating the CHyprOpenGLImpl!
[LOG] Creating the Hypr OpenGL Renderer!
[LOG] Using: OpenGL ES 3.2 Mesa 24.0.4-1
[LOG] Vendor: AMD
[LOG] Renderer: AMD Radeon Graphics (radeonsi, renoir, LLVM 17.0.6, DRM 3.57, 6.7.9-amd64)
[LOG] Supported extensions size: 154
[WARN] !RENDERER: Using the legacy GLES2 renderer!
[LOG] Creating the HyprRenderer!
[LOG] DRM driver information: amdgpu v3.57.0 from 20150101 description AMD GPU
[LOG] [hookSystem] New hook event registered: keyPress
[LOG] [hookSystem] New hook event registered: mouseMove
[LOG] Creating the XWaylandManager!
[LOG] Registered signal for owner 564b8df96130: 564b8df96178 -> 564b8bd5e140 (owner: XWayland Manager)
[LOG] Registered signal for owner 564b8df96130: 564b8df96188 -> 564b8bd5e120 (owner: XWayland Manager)
[LOG] CHyprXWaylandManager started on display :1
[LOG] Creating the ProtocolManager!
[WARN] Toplevel sharing is not supported on LEGACY_RENDERER!
[LOG] FractionalScaleManager started successfully!
[LOG] TextInputV1Manager started successfully!
[LOG] GlobalShortcutsManager started successfully!
[LOG] ScreencopyProtocolManager started successfully!