### PR TITLE
fix: update color-type references

### DIFF
--- a/src/SelectionHook.cpp
+++ b/src/SelectionHook.cpp
@@ -42,7 +42,7 @@ void init() {
 		         "Failed to load function hooks: "
 		         "\"updateWindowAnimatedDecorationValues\""},
 		        {"time", (uint64_t) 10000},
-		        {"color", CColor(1.0, 0.0, 0.0, 1.0)},
+		        {"color", CHyprColor(1.0, 0.0, 0.0, 1.0)},
 		        {"icon", ICON_ERROR},
 		    }
 		);

--- a/src/TabGroup.cpp
+++ b/src/TabGroup.cpp
@@ -170,8 +170,8 @@ void Hy3TabBarEntry::prepareTexture(float scale, CBox& box) {
 		auto focused = this->focused.value();
 		auto urgent = this->urgent.value();
 		auto inactive = 1.0 - (focused + urgent);
-		auto c = (CColor(*col_active) * focused) + (CColor(*col_urgent) * urgent)
-		       + (CColor(*col_inactive) * inactive);
+		auto c = (CHyprColor(*col_active) * focused) + (CHyprColor(*col_urgent) * urgent)
+		       + (CHyprColor(*col_inactive) * inactive);
 
 		cairo_set_source_rgba(cairo, c.r, c.g, c.b, c.a);
 
@@ -214,8 +214,8 @@ void Hy3TabBarEntry::prepareTexture(float scale, CBox& box) {
 			pango_layout_set_width(layout, width * PANGO_SCALE);
 			pango_layout_set_ellipsize(layout, PANGO_ELLIPSIZE_END);
 
-			auto c = (CColor(*col_text_active) * focused) + (CColor(*col_text_urgent) * urgent)
-			       + (CColor(*col_text_inactive) * inactive);
+			auto c = (CHyprColor(*col_text_active) * focused) + (CHyprColor(*col_text_urgent) * urgent)
+			       + (CHyprColor(*col_text_inactive) * inactive);
 
 			cairo_set_source_rgba(cairo, c.r, c.g, c.b, c.a);
 
@@ -600,7 +600,7 @@ void Hy3TabGroup::renderTabBar() {
 			window_box.scale(scale);
 
 			if (window_box.width > 0 && window_box.height > 0)
-				g_pHyprOpenGL->renderRect(&window_box, CColor(0, 0, 0, 0), *window_rounding);
+				g_pHyprOpenGL->renderRect(&window_box, CHyprColor(0, 0, 0, 0), *window_rounding);
 		}
 
 		glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -18,7 +18,7 @@ inline void errorNotif() {
 	    {
 	        {"text", "Something has gone very wrong. Check the log for details."},
 	        {"time", (uint64_t) 10000},
-	        {"color", CColor(1.0, 0.0, 0.0, 1.0)},
+	        {"color", CHyprColor(1.0, 0.0, 0.0, 1.0)},
 	        {"icon", ICON_ERROR},
 	    }
 	);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,7 +16,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 		HyprlandAPI::addNotification(
 		    PHANDLE,
 		    "[hy3] hy3 was compiled for a different version of hyprland; refusing to load.",
-		    CColor {1.0, 0.2, 0.2, 1.0},
+		    CHyprColor {1.0, 0.2, 0.2, 1.0},
 		    10000
 		);
 


### PR DESCRIPTION
I wasn't able to build against upstream due to the renaming of the `CColor` enumeration