### PR TITLE
Add multimonitor support for movewindow

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1806,7 +1806,7 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
             if (next_monitor && next_monitor->activeWorkspace) {
                 moveNodeToWorkspace(node.workspace.get(), 
                                   next_monitor->activeWorkspace->m_szName, 
-                                  true, false, direction);
+                                  true, true, direction);
                 return nullptr;
             }
         }

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1734,6 +1734,24 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
     bool once,
     bool visible
 ) {
+
+    auto* parent = node.parent;
+    if (shift && parent && parent->parent == nullptr &&
+        parent->data.as_group().layout != Hy3GroupLayout::Tabbed &&
+        shiftMatchesLayout(parent->data.as_group().layout, direction)) {
+        // Check if we're at the edge
+        auto& children = parent->data.as_group().children;
+        bool at_edge = (shiftIsForward(direction) && &node == children.back()) ||
+                      (!shiftIsForward(direction) && &node == children.front());
+        if (at_edge) {
+            auto next_monitor = g_pCompositor->getMonitorInDirection(getShiftDirectionChar(direction));
+            if (next_monitor && next_monitor->activeWorkspace) {
+                moveNodeToWorkspace(node.workspace.get(), next_monitor->activeWorkspace->m_szName, true, false);
+                return nullptr;
+            }
+        }
+    }
+
 	auto* break_origin = &node.getExpandActor();
 	auto* break_parent = break_origin->parent;
 

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -165,6 +165,7 @@ public:
 private:
 	Hy3Node* getNodeFromWindow(const CWindow*);
 	void applyNodeDataToWindow(Hy3Node*, bool no_animation = false);
+	bool isAtEdgeWithNoMovement(Hy3Node& node, ShiftDirection direction);
 
 	// if shift is true, shift the window in the given direction, returning
 	// nullptr, if shift is false, return the window in the given direction or

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -127,7 +127,7 @@ public:
 	Hy3Node* focusMonitor(ShiftDirection);
 
 	void warpCursor();
-	void moveNodeToWorkspace(CWorkspace* origin, std::string wsname, bool follow, bool warp);
+	void moveNodeToWorkspace(CWorkspace* origin, std::string wsname, bool follow, bool warp, ShiftDirection direction = ShiftDirection::Right);
 	void changeFocus(const CWorkspace* workspace, FocusShift);
 	void focusTab(
 	    const CWorkspace* workspace,
@@ -183,3 +183,8 @@ private:
 
 	friend struct Hy3Node;
 };
+
+
+bool shiftIsForward(ShiftDirection direction);
+bool shiftIsVertical(ShiftDirection direction);
+bool shiftMatchesLayout(Hy3GroupLayout layout, ShiftDirection direction);


### PR DESCRIPTION
This PR makes progress on resolving [#162](https://github.com/outfoxxed/hy3/issues/162) by enabling `hy3:movewindow` to move focused windows between monitors. While it functions as expected in most cases, it does not always ensure the window is placed exactly at the edge of the next monitor.

It has been working well for my personal use cases, but further testing is required to validate its behavior across different setups. Feedback and additional testing would be greatly appreciated!

Looking forward to any insights or suggestions. 🚀