### PR TITLE
Fix: movefocus & wrong focus on closing

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -926,7 +926,7 @@ void Hy3Layout::shiftFocus(
 		}
 
 		target->focus(warp);
-		if (node->parent == target->parent && node->parent->data.as_group().layout == Hy3GroupLayout::Tabbed) {
+		if (node->parent != nullptr && node->parent == target->parent && node->parent->data.as_group().layout == Hy3GroupLayout::Tabbed) {
 			g_pInputManager->simulateMouseMovement();
 		}
 		while (target->parent != nullptr) target = target->parent;

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -926,6 +926,9 @@ void Hy3Layout::shiftFocus(
 		}
 
 		target->focus(warp);
+		if (node->parent == target->parent && node->parent->data.as_group().layout == Hy3GroupLayout::Tabbed) {
+			g_pInputManager->simulateMouseMovement();
+		}
 		while (target->parent != nullptr) target = target->parent;
 		target->recalcSizePosRecursive();
 	}

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -140,7 +140,6 @@ public:
 	void killFocusedNode(const CWorkspace* workspace);
 	void expand(const CWorkspace* workspace, ExpandOption, ExpandFullscreenOption);
 	static void warpCursorToBox(const Vector2D& pos, const Vector2D& size);
-	static void warpCursorWithFocus(const Vector2D& pos, bool force = false);
 
 	bool shouldRenderSelected(const CWindow*);
 	PHLWINDOW findTiledWindowCandidate(const CWindow* from);

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -771,7 +771,7 @@ Hy3Node* Hy3Node::removeFromParentRecursive(Hy3Node** expand_actor) {
 		parent = parent->parent;
 		auto& group = parent->data.as_group();
 
-		if (group.children.size() > 2) {
+		if (group.children.size() > 2 && group.focused_child == child) {
 			auto iter = std::find(group.children.begin(), group.children.end(), child);
 
 			group.group_focused = false;


### PR DESCRIPTION
This fix mouse clicks being sent to the wrong window after changing focus, when both old and new windows are in the same node of type `group`. I didn't pump commit in `hyprpm.toml`. I don't mind squash merge.

I think only one of `node->parent != nullptr` or `target->parent == nullptr` is needed in this particular case, right?

This also fix wrong behavior on window close.