### PR TITLE
Fix/mouse button hook behavior

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1613,6 +1613,7 @@ void Hy3Layout::mouseButtonHook(void*, SCallbackInfo& info, std::any data) {
 		focus = focus->data.as_group().focused_child;
 
 	focus->focus(false);
+	g_pInputManager->simulateMouseMovement();
 	tab_node->recalcSizePosRecursive();
 
 	info.cancelled = true;

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1595,7 +1595,7 @@ void Hy3Layout::mouseButtonHook(void*, SCallbackInfo& info, std::any data) {
 
 	// non window-parented surface focused, cant have a tab
 	auto window = ptr_surface->getWindow();
-	if (!window || window->m_bIsFloating) return;
+	if (!window || window->m_bIsFloating || window->isFullscreen()) return;
 
 	auto* node = g_Hy3Layout->getNodeFromWindow(window.get());
 	if (!node) return;


### PR DESCRIPTION
Fixes clicking on tab while in fullscreen. Right now, it switches the focus when clicking on a tab while the current window is in fullscreen.

This also fix, not simulating mouse resulting in the current window not getting mouse clicks after switching the window via clicking on the tab and then going fullscreen. To reproduce:

- Make a group node with two windows
- Select window on tab index 1
- Select window on tab index 2 via a mouse click
- WITHOUT moving the mouse, issue a fullscreen dispatch
- perform mouse clicks WITHOUT moving the mouse, they won't be registered

The 2nd issue isn't a big deal on desktops, but on laptops with a touchpad and physical mouse buttons(for example thinkpads) it is very noticeable.