### PR TITLE
Use correct config value for focused text color

### DIFF
--- a/src/TabGroup.cpp
+++ b/src/TabGroup.cpp
@@ -219,7 +219,7 @@ void Hy3TabBarEntry::renderText(float scale, CBox& box, float opacity) {
 	static const auto text_height = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:text_height");
 	static const auto text_padding = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:text_padding");
 	static const auto col_text_active = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:col.active.text");
-	static const auto col_text_focused = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:col.active.text");
+	static const auto col_text_focused = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:col.focused.text");
 	static const auto col_text_urgent = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:col.urgent.text");
 	static const auto col_text_locked = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:col.locked.text");
 	static const auto col_text_inactive = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:col.inactive.text");


### PR DESCRIPTION
This PR is a one-line change that fixed the inactive focused tab's text color being incorrectly set to the value for the active tab's text color. Just something I noticed in passing this morning while working on other things. I've built and tested locally and it resolved the issue, but please let me know if there are any other requirements for this pull request. Thanks!