### PR TITLE
fix: prevent tab bars from overlaying on special workspace tab bars

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1590,13 +1590,19 @@ void Hy3Layout::renderHook(void*, SCallbackInfo&, std::any data) {
 		rendering_normally = false;
 
 		for (auto& entry: g_Hy3Layout->tab_groups) {
-			if (!entry.hidden && entry.target_window->m_pMonitor == g_pHyprOpenGL->m_RenderData.pMonitor
-			    && (!entry.target_window->m_pWorkspace || entry.target_window->m_pWorkspace->m_bVisible)
-			    && std::find(rendered_groups.begin(), rendered_groups.end(), &entry)
-			           == rendered_groups.end())
-			{
-				g_pHyprRenderer->m_sRenderPass.add(entry.pass);
-				entry.renderTabBar();
+			if (!entry.hidden && entry.target_window->m_pMonitor == g_pHyprOpenGL->m_RenderData.pMonitor) {
+				auto active_workspace = g_pCompositor->m_pLastMonitor->activeSpecialWorkspace;
+				if (!valid(active_workspace)) {
+					active_workspace = g_pCompositor->m_pLastMonitor->activeWorkspace;
+				}
+
+				if (entry.target_window->m_pWorkspace == active_workspace
+				    && std::find(rendered_groups.begin(), rendered_groups.end(), &entry)
+				           == rendered_groups.end())
+				{
+					g_pHyprRenderer->m_sRenderPass.add(entry.pass);
+					entry.renderTabBar();
+				}
 			}
 		}
 


### PR DESCRIPTION
This PR fixes an issue where tab bars from regular workspaces were overlaying on special workspace tab bars. The fix ensures that only tab bars for the currently active workspace (either special or regular) are rendered.