### PR TITLE
Add extra color for active windows on inactive monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# Upcoming
+
+- Added `active_alt_monitor` tab bar color options.
+
 # hl0.51.0 and before
 
 - Only compatibility fixes.

--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ plugin {
       col.active.border = <color> # default: rgba(33ccffee)
       col.active.text = <color> # default: rgba(ffffffff)
 
+      # active tab bar segment colors for bars on an unfocused monitor
+      col.active_alt_monitor = <color> # default: rgba(60606040)
+      col.active_alt_monitor.border = <color> # default: rgba(808080ee)
+      col.active_alt_monitor.text = <color> # default: rgba(ffffffff)
+
       # focused tab bar segment colors (focused node in unfocused container)
       col.focused = <color> # default: rgba(60606040)
       col.focused.border = <color> # default: rgba(808080ee)

--- a/src/TabGroup.hpp
+++ b/src/TabGroup.hpp
@@ -21,12 +21,13 @@ struct Hy3TabBarEntry {
 	PHLANIMVAR<float> active;
 	PHLANIMVAR<float> focused;
 	PHLANIMVAR<float> urgent;
+	PHLANIMVAR<float> active_monitor;
 	PHLANIMVAR<float> offset;       // 0.0-1.0 of total bar
 	PHLANIMVAR<float> width;        // 0.0-1.0 of total bar
 	PHLANIMVAR<float> vertical_pos; // 0.0-1.0, user specified direction
 	PHLANIMVAR<float> fade_opacity; // 0.0-1.0
 	Hy3TabBar& tab_bar;
-	Hy3Node& node; // only used for comparioson. do not deref.
+	Hy3Node& node; // only used for comparison. do not deref.
 
 	struct {
 		float scale = 0.0;
@@ -54,6 +55,7 @@ struct Hy3TabBarEntry {
 	void setFocused(bool);
 	void setUrgent(bool);
 	void setWindowTitle(std::string);
+	void setMonitorActive(bool);
 	void beginDestroy();
 	void unDestroy();
 	bool shouldRemove();
@@ -66,6 +68,7 @@ private:
 	    const CHyprColor& focused,
 	    const CHyprColor& urgent,
 	    const CHyprColor& locked,
+	    const CHyprColor& inactiveMonitor,
 	    const CHyprColor& inactive
 	);
 };
@@ -77,6 +80,8 @@ public:
 	bool damaged = true;
 	PHLANIMVAR<float> fade_opacity;
 	PHLANIMVAR<float> locked;
+	// The monitor this bar resides on
+	MONITORID monitor_id = MONITOR_INVALID;
 
 	Hy3TabBar();
 	void beginDestroy();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,9 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("tabs:col.active", INT, 0x4033ccff);
 	CONF("tabs:col.active.border", INT, 0xee33ccff);
 	CONF("tabs:col.active.text", INT, 0xffffffff);
+	CONF("tabs:col.active_alt_monitor", INT, 0xffff0000);
+	CONF("tabs:col.active_alt_monitor.border", INT, 0xee808080);
+	CONF("tabs:col.active_alt_monitor.text", INT, 0xffffffff);
 	CONF("tabs:col.focused", INT, 0x40606060);
 	CONF("tabs:col.focused.border", INT, 0xee808080);
 	CONF("tabs:col.focused.text", INT, 0xffffffff);


### PR DESCRIPTION
This allows changing the tab color on a tab that is focused when another monitor is focused. This uses the same color as `active` to provide backwards compatibility on existing configs.