### PR TITLE
docs(readme): explicitly enable hy3 plugin after install

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ To install hy3 via hyprpm run
 hyprpm add https://github.com/outfoxxed/hy3
 ```
 
+To enable hy3, run
+
+```sh
+hyprpm enable hy3
+```
+
 To update hy3 (and all other plugins), run
 
 ```sh


### PR DESCRIPTION
# Docs
- Add snippet on how to explicitly enable the plugin after install