### PR TITLE
Fix segfault in `hy3:movetoworkspace`

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1140,8 +1140,10 @@ void Hy3Layout::moveNodeToWorkspace(
 		monitor->changeWorkspace(workspace);
 		if (*allow_workspace_cycles) workspace->rememberPrevWorkspace(origin_ws);
 
-		node->parent->recalcSizePosRecursive();
-		node->focus(warp);
+		if (node) {
+			node->parent->recalcSizePosRecursive();
+			node->focus(warp);
+		}
 	}
 }
 


### PR DESCRIPTION
Happened when `hy3:movetoworkspace` was called with the `follow` argument and there was only one floating window on the workspace (so no tree nodes).