### PR TITLE
feat: add hy3:equalize dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,3 +390,6 @@ plugin {
    - `expand` - expand by one node
    - `shrink` - shrink by one node
    - `base` - undo all expansions
+ - `hy3:equalize, [workspace]` - equalize window sizes in group
+   - no argument: equalizes immediate siblings of the focused window
+   - `workspace`: equalizes all windows across the entire workspace tree

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1514,6 +1514,39 @@ void Hy3Layout::setTabLock(const CWorkspace* workspace, TabLockMode mode) {
 	node->updateTabBar();
 }
 
+static void equalizeRecursive(Hy3Node* node, bool recursive) {
+	node->size_ratio = 1.0f;
+
+	if (recursive && node->data.is_group()) {
+		for (auto* child: node->data.as_group().children) {
+			equalizeRecursive(child, true);
+		}
+	}
+}
+
+void Hy3Layout::equalize(const CWorkspace* workspace, bool recursive) {
+	auto* focused = this->getWorkspaceFocusedNode(workspace);
+	if (focused == nullptr) return;
+
+	Hy3Node* target = nullptr;
+
+	if (recursive) {
+		target = this->getWorkspaceRootGroup(workspace);
+		if (target != nullptr) {
+			equalizeRecursive(target, true);
+		}
+	} else {
+		if (focused->parent == nullptr) return;
+		auto* parent = focused->parent;
+		equalizeRecursive(parent, false);
+		target = parent;
+	}
+
+	if (target != nullptr) {
+		target->recalcSizePosRecursive();
+	}
+}
+
 void Hy3Layout::warpCursorToBox(const Vector2D& pos, const Vector2D& size) {
 	auto cursorpos = g_pPointerManager->position();
 

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -151,6 +151,7 @@ public:
 	void killFocusedNode(const CWorkspace* workspace);
 	void expand(const CWorkspace* workspace, ExpandOption, ExpandFullscreenOption);
 	void setTabLock(const CWorkspace* workspace, TabLockMode);
+	void equalize(const CWorkspace* workspace, bool recursive = false);
 	static void warpCursorToBox(const Vector2D& pos, const Vector2D& size);
 	static void warpCursorWithFocus(const Vector2D& pos, bool force = false);
 

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -264,6 +264,14 @@ void dispatch_locktab(std::string arg) {
 	g_Hy3Layout->setTabLock(workspace.get(), mode);
 }
 
+void dispatch_equalize(std::string arg) {
+	auto workspace = workspace_for_action();
+	if (!valid(workspace)) return;
+
+	bool recursive = (arg == "workspace");
+	g_Hy3Layout->equalize(workspace.get(), recursive);
+}
+
 SDispatchResult dispatch_debug(std::string arg) {
 	auto workspace = workspace_for_action();
 
@@ -292,5 +300,6 @@ void registerDispatchers() {
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:killactive", dispatch_killactive);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:expand", dispatch_expand);
 	HyprlandAPI::addDispatcher(PHANDLE, "hy3:locktab", dispatch_locktab);
+	HyprlandAPI::addDispatcher(PHANDLE, "hy3:equalize", dispatch_equalize);
 	HyprlandAPI::addDispatcherV2(PHANDLE, "hy3:debugnodes", dispatch_debug);
 }


### PR DESCRIPTION
Add a new dispatcher to equalize window sizes within a group or recursively across the entire workspace tree.

## Usage

```bash
hy3:equalize           # equalize siblings of focused window
hy3:equalize recursive # equalize all windows in workspace
```

## Modes

**Default (no args):** Equalizes only the immediate siblings of the focused window. Useful for surgical adjustments at one level without affecting nested groups.

```
| A |   B   |  →  |  A  |  B  |
    |B1|B2|           |B1|B2|  ← unchanged
```

**Recursive:** Equalizes the entire workspace tree - all nodes at all nesting levels. The "reset everything" option.

```
| A |   B   |  →  |  A  |  B  |
    |B1|B2|       |B1|B2|  ← also equalized
```

## Implementation

Resets `size_ratio` to 1.0 for affected nodes and triggers a single `recalcSizePosRecursive()` call, providing instant equalization without the overhead of iterative resizing via hyprctl.