### PR TITLE
Fixed a crash in the "makegroup" dispatcher

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -745,7 +745,7 @@ void Hy3Layout::makeGroupOnWorkspace(
 		auto* parent = node->parent;
 		auto& group = parent->data.as_group();
 
-		if (group.children.size() == 1 && group.layout == layout) {
+		if (group.children.size() == 1 && group.layout == layout && parent->parent != nullptr) {
 			group.children.clear();
 			Hy3Node::swapData(*node, *parent);
 			this->nodes.remove(*node); // now the parent


### PR DESCRIPTION
If the "toggle" option is enabled and the group being created is the same as the group the current node is in and the current node is the only node in that group and that node is the only node in the workspace, then a crash will occur. As best as I can tell, this is because the parent of the parent of the target node is a `nullptr`. To fix this, I've updated the conditional to check that parent.

Note that a crash still occurs if you've got multiple nodes selected. I'm not super familiar with the code base and haven't yet been able to track that issue down, so perhaps someone else could point me in the right direction?