### PR TITLE
Add option to spawn windows from the center

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,24 @@ plugin {
       opacity = <float> # default: 1.0
     }
 
+    # window settings
+    window {
+      # "default" = default layout orientation
+      # "center" = center the windows on the monitor
+      layout_orientation = <string> # default: "default"
+
+      # max number of windows to activate the center layout on the monitor
+      center_max_count = <int> # default: 2
+
+      # width percentage of the window to center on the monitor
+      width_pct = <float> # default: 70.0
+
+      # list of monitors that will use the center layout
+      # if empty, the center layout will be activated on all monitors
+      # example: "DP-1, DP-2"... etc.
+      center_layout_monitors = <string> # default: ""
+    }
+
     # autotiling settings
     autotile {
       # enable autotile

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -319,10 +319,19 @@ void Hy3Node::recalcSizePosRecursive(bool no_animation) {
 	static const auto group_inset = ConfigValue<Hyprlang::INT>("plugin:hy3:group_inset");
 	static const auto tab_bar_height = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:height");
 	static const auto tab_bar_padding = ConfigValue<Hyprlang::INT>("plugin:hy3:tabs:padding");
-
+	static const auto p_window_orientation = ConfigValue<Hyprlang::STRING>("plugin:hy3:window:layout_orientation");
+	static const auto p_center_max_count = ConfigValue<Hyprlang::INT>("plugin:hy3:window:center_max_count");
+	static const auto p_width_pct  = ConfigValue<Hyprlang::FLOAT>("plugin:hy3:window:width_pct");
+	static const auto p_center_layout_monitors = ConfigValue<Hyprlang::STRING>("plugin:hy3:window:center_layout_monitors");
+	
 	auto workspace_rule = g_pConfigManager->getWorkspaceRuleFor(this->workspace);
 	auto gaps_in = workspace_rule.gapsIn.value_or(*p_gaps_in);
 	auto gaps_out = workspace_rule.gapsOut.value_or(*p_gaps_out);
+	auto window_orientation = std::string (*p_window_orientation);
+	auto center_layout_monitors = std::string (*p_center_layout_monitors);
+	auto window_width_pct = *p_width_pct;
+	auto center_max_count = (size_t) *p_center_max_count;
+	auto monitor = this->getMonitor();
 
 	auto gap_topleft_offset = Vector2D(
 	    (int) -(gaps_in.m_left - gaps_out.m_left),
@@ -337,7 +346,6 @@ void Hy3Node::recalcSizePosRecursive(bool no_animation) {
 
 	if (this->data.is_window() && this->data.as_window()->isFullscreen()) {
 		auto window = this->data.as_window();
-		auto& monitor = this->workspace->m_monitor;
 
 		if (window->isEffectiveInternalFSMode(FSMODE_FULLSCREEN)) {
 			*window->m_realPosition = monitor->m_position;
@@ -364,6 +372,26 @@ void Hy3Node::recalcSizePosRecursive(bool no_animation) {
 	} else {
 		gap_topleft_offset = this->gap_topleft_offset;
 		gap_bottomright_offset = this->gap_bottomright_offset;
+	}
+
+	bool is_centered_monitor = center_layout_monitors.empty()
+	                        || center_layout_monitors.find(monitor->m_name) != std::string::npos;
+
+	if (this->parent == nullptr && this->data.is_group() && window_orientation == "center"
+	    && is_centered_monitor)
+	{
+		auto& group = this->data.as_group();
+		auto child_count = group.children.size();
+		auto max_center_width =
+		    monitor->m_size.x * std::clamp((double) window_width_pct, 30.0, 100.0) / 100.0;
+
+		if (child_count <= center_max_count) {
+			this->size.x = max_center_width;
+			this->position.x = monitor->m_position.x + (monitor->m_size.x - max_center_width) / 2.0;
+		} else {
+			this->position.x = monitor->m_position.x;
+			this->size.x = monitor->m_size.x;
+		}
 	}
 
 	auto tpos = this->position;

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -385,7 +385,7 @@ void Hy3Node::recalcSizePosRecursive(bool no_animation) {
 		auto max_center_width =
 		    monitor->m_size.x * std::clamp((double) window_width_pct, 30.0, 100.0) / 100.0;
 
-		if (child_count <= center_max_count) {
+		    if (child_count <= center_max_count || group.layout == Hy3GroupLayout::Tabbed) { // this for now. We should check visible windows to see if we can center or not, but maybe we have to count each child recursively
 			this->size.x = max_center_width;
 			this->position.x = monitor->m_position.x + (monitor->m_size.x - max_center_width) / 2.0;
 		} else {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("tabs:col.locked.border", INT, 0xee909033);
 	CONF("tabs:col.locked.text", INT, 0xffffffff);
 
+	CONF("window:layout_orientation", STRING, "default");
+	CONF("window:center_max_count", INT, 2);
+	CONF("window:width_pct", FLOAT, 70.0);
+	CONF("window:center_layout_monitors", STRING, "");
+
 	// autotiling
 	CONF("autotile:enable", INT, 0);
 	CONF("autotile:ephemeral_groups", INT, 1);


### PR DESCRIPTION
Adds an option to center the windows instead of the default placement. This is useful for ultrawide monitors. 
Resolves #264  

https://github.com/user-attachments/assets/1607e849-0dbd-4113-814e-8b8af7bc823b

