### PR TITLE
Fixed movefocus regression across monitor boundaries

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -826,9 +826,11 @@ Hy3Node* Hy3Layout::focusMonitor(ShiftDirection direction) {
 				found = true;
 
 				// Move the cursor to the window we selected
-				auto found_node = getNodeFromWindow(target_window.get());
+				auto* target_layout = hy3InstanceForWorkspace(next_workspace);
+				auto found_node = target_layout ? target_layout->getNodeFromWindow(target_window.get()) : nullptr;
 				if (found_node) {
 					found_node->focus(true, Desktop::FOCUS_REASON_KEYBIND);
+					this->updateGroupBorderColors();
 					return found_node;
 				}
 			}


### PR DESCRIPTION
This PR fixes issues with `movefocus` when moving across monitor boundaries. In particular it should now focus the correct window and update border colours correctly.
Fixes #288 