### PR TITLE
fix: null guard m_monitor in Hy3TabGroup::tick()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Upcoming
 
 - Fixed a crash when using locked opaque tabs.
+- Fixed a crash when removing a monitor.
 
 # hl0.54.2.1 and before
 

--- a/src/TabGroup.cpp
+++ b/src/TabGroup.cpp
@@ -650,7 +650,7 @@ void Hy3TabGroup::tick() {
 
 	this->bar.tick();
 
-	if (valid(this->workspace)) {
+	if (valid(this->workspace) && this->workspace->m_monitor) {
 		auto has_fullscreen = this->workspace->m_hasFullscreenWindow;
 
 		if (!has_fullscreen && *no_gaps_when_only) {


### PR DESCRIPTION
workspace->m_monitor can be null during monitor disconnect (dpms off), causing a SEGV when dereferencing m_monitor->m_id.

Crash backtrace:

```
Backtrace:
	# | Hyprland(_Z12getBacktracev+0x61) [0x55a228283121]
		getBacktrace()
		??:?
	#1 | Hyprland(_ZN13CrashReporter18createAndSaveCrashEi+0xcd6) [0x55a2281e6026]
		CrashReporter::createAndSaveCrash(int)
		??:?
	#2 | Hyprland(+0x284bde) [0x55a228135bde]
		std::__format::_Formatting_scanner<std::__format::_Sink_iter<char>, char>::_M_format_arg(unsigned long)
		??:?
	#3 | /usr/lib/libc.so.6(+0x3e2d0) [0x7ff38ae4d2d0]
		??
		??:0
	#4 | /var/cache/hyprpm/pavle/hy3/hy3.so(_ZN11Hy3TabGroup4tickEv+0x728) [0x7ff3542daf58]
		??
		??:0
	#5 | /var/cache/hyprpm/pavle/hy3/hy3.so(_ZN7Hy3Node12updateTabBarEb+0xd7) [0x7ff3542cfad7]
		??
		??:0
	#6 | /var/cache/hyprpm/pavle/hy3/hy3.so(_ZN7Hy3Node21updateTabBarRecursiveEv+0xa6) [0x7ff3542cfec6]
		??
		??:0
	#7 | /var/cache/hyprpm/pavle/hy3/hy3.so(+0x2cfed) [0x7ff354290fed]
		??
		??:0
```