### PR TITLE
fix(movewindow): prevent windows from escaping tab groups

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1493,7 +1493,7 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 
 			// if this movement would break out of the group, continue the break loop
 			// (do not enter this if) otherwise break.
-			if ((has_broken_once && once && shift)
+			if ((has_broken_once && shift && (once || group.isTab()))
 			    || !(
 			        (!shiftIsForward(direction) && group.children.front().get() == break_origin)
 			        || (shiftIsForward(direction) && group.children.back().get() == break_origin)
@@ -1542,7 +1542,7 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 				|| (node.is_group()
 						&& (node.as_group().expand_focused != ExpandFocusType::NotExpanded
 								|| node.as_group().locked))
-				|| (shift && once && has_broken_once))
+				|| (shift && has_broken_once && (once || parent_group.isTab())))
 		{
 			if (shift) {
 				if (target_group == shift_actor->parent.get()) {

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1493,7 +1493,9 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 
 			// if this movement would break out of the group, continue the break loop
 			// (do not enter this if) otherwise break.
-			if ((has_broken_once && shift && (once || group.isTab()))
+			if ((has_broken_once && shift
+			     && (once || group.isTab()
+			         || (break_parent->parent && break_parent->parent->as_group().isTab())))
 			    || !(
 			        (!shiftIsForward(direction) && group.children.front().get() == break_origin)
 			        || (shiftIsForward(direction) && group.children.back().get() == break_origin)


### PR DESCRIPTION
## Summary

When using `hy3:movewindow` to move a window out of a sub-group (e.g. `SplitH`) nested inside a tab group, the window escapes the tab group entirely instead of being placed as a sibling within it.

For example, given `t(h(a, b))`, moving `b` to the right should produce `t(h(a), b)`, but instead `b` exits the tab group completely.

## Root cause

In `shiftOrGetFocus`, the parent traversal loop uses `once` as the sole condition to stop at group boundaries after breaking out of a child group. Since `once` is `false` by default, the loop keeps climbing past tab groups. Similarly, after the break, the neighbor descent logic enters adjacent groups instead of placing the window next to them.

## Fix

Two one-line changes in `src/Hy3Layout.cpp`:

1. **Break condition (line 1477):** Add `group.isTab()` so the traversal loop stops at tab group boundaries:
   ```diff
   - if ((has_broken_once && once && shift)
   + if ((has_broken_once && shift && (once || group.isTab()))
   ```

2. **Neighbor descent guard (line 1526):** Add `parent_group.isTab()` so the window is placed next to the neighboring group instead of descending into it:
   ```diff
   - || (shift && once && has_broken_once))
   + || (shift && has_broken_once && (once || parent_group.isTab())))
   ```

## Testing

Manually tested the following scenarios:

| # | Initial tree | Action | Expected result | Status |
|---|---|---|---|---|
| 1 | `t(h(a, b))` | movewindow right on `b` | `t(h(a), b)` | Pass |
| 2 | `t(a, b, c)` | movewindow right on `b` | `t(a, c, b)` | Pass |
| 3 | `t(a)` | movewindow right on `a` | exits tab group | Pass |
| 4 | `h(a, b)` | movewindow right on `a` | `h(b, a)` (unchanged) | Pass |
| 5 | `t(v(a, b))` | movewindow down on `a` | `t(v(b, a))` (unchanged) | Pass |
| 6 | `t(h(a, b), c)` | movewindow right on `b` | `t(h(a), b, c)` | Pass |
| 7 | `h(t(a,b,c), d)` | movewindow left on `d` | `t(a,b,c,d)` | Pass |