### PR TITLE
fix(wrap): only collapse single-child wrap for split parents

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -707,7 +707,7 @@ void Hy3Layout::makeOppositeGroupOn(Hy3Node& node, GroupEphemeralityOption ephem
 	auto layout =
 	    group.layout == Hy3GroupLayout::SplitH ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH;
 
-	if (group.children.size() == 1) {
+	if (group.children.size() == 1 && group.isSplit()) {
 		group.setLayout(layout);
 		group.setEphemeral(ephemeral);
 		this->recalcGeometry();
@@ -1493,7 +1493,8 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 
 			// if this movement would break out of the group, continue the break loop
 			// (do not enter this if) otherwise break.
-			if ((has_broken_once && once && shift)
+			if ((has_broken_once && shift
+			     && (once || (break_parent->parent && break_parent->parent->as_group().isTab())))
 			    || !(
 			        (!shiftIsForward(direction) && group.children.front().get() == break_origin)
 			        || (shiftIsForward(direction) && group.children.back().get() == break_origin)
@@ -1542,7 +1543,8 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 				|| (node.is_group()
 						&& (node.as_group().expand_focused != ExpandFocusType::NotExpanded
 								|| node.as_group().locked))
-				|| (shift && once && has_broken_once))
+				|| (shift && has_broken_once
+				    && (once || parent_group.isTab())))
 		{
 			if (shift) {
 				if (target_group == shift_actor->parent.get()) {

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -704,7 +704,9 @@ static bool shouldCollapseNode(Hy3Node* node, CollapsePolicy policy) {
 
 	if (child->is_group()) {
 		auto& cgroup = child->as_group();
-		if (group.isSplit() && cgroup.isSplit()) return true;
+		if (group.isSplit() && cgroup.isSplit()
+		    && (node->is_root() || node->parent->as_group().isSplit()))
+			return true;
 		if (cgroup.children.size() == 1 && group.isTab() && cgroup.isTab()) return true;
 	}
 
@@ -812,7 +814,9 @@ void Hy3Node::insertAndMerge(UP<Hy3Node> child, CollapsePolicy policy) {
 
 void Hy3Node::wrap(Hy3GroupLayout layout, GroupEphemeralityOption ephemeral, bool change) {
 	auto& parentGroup = this->parent->as_group();
-	if (change && !this->parent->is_root() && parentGroup.children.size() == 1) {
+	if (change && !this->parent->is_root() && parentGroup.children.size() == 1
+	    && parentGroup.isSplit())
+	{
 		parentGroup.setLayout(layout);
 		parentGroup.setEphemeral(ephemeral);
 		this->layout()->recalcGeometry();


### PR DESCRIPTION
## Problem

When a tab group contains a single split child (e.g. `t(v(a,b))`), `hy3:makegroup h` with the child group focused does not create a new wrapper. Instead, `wrap()` takes a shortcut that results in no visible change rather than creating a new wrapper group.

**Steps to reproduce:**
1. Create a tab group with a vertical split: `t(v(a,b))`
2. Focus the vertical group with `hy3:changefocus raise`
3. Run `hy3:makegroup h`

**Expected:** `t(h(v(a,b)))`
**Actual:** No visible change

Three places assume single-child groups are always redundant, without considering that a split inside a tab is intentional:
- `Hy3Node::wrap()` reuses the parent when it has one child, regardless of parent type
- `shouldCollapseNode()` collapses any split-in-split, even inside tabs
- `shiftOrGetFocus()` traverses through single-child splits even when their parent is a tab

i3 and Sway only apply the single-child shortcut when the parent layout is H or V, not when it is tabbed or stacked.

## Changes
- `Hy3Node::wrap()`: add `parentGroup.isSplit()` to the single-child shortcut condition
- `shouldCollapseNode()`: skip split-in-split collapse when the node's parent is a tab group
- `makeOppositeGroupOn()`: add `group.isSplit()` to the single-child shortcut condition
- `shiftOrGetFocus()`: break the traversal loop when the current group's parent is a tab