### PR TITLE
feat: add smart_split mouse insertion

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ plugin {
     # if a tab group will automatically be created for the first window spawned in a workspace
     tab_first_window = <bool>
 
+    # if mouse drops should choose left/right/top/bottom insertion from the cursor's triangle over the target
+    smart_split = <bool> # default: false
+
     # tab group settings
     tabs {
       # height of the tab bar

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1,4 +1,5 @@
 #include <cstdint>
+#include <cmath>
 #include <regex>
 #include <optional>
 #include <set>
@@ -72,6 +73,25 @@ std::string operationWorkspaceForName(const std::string& workspace) {
 }
 
 Hy3Node* findTabBarAt(Hy3Node& node, Vector2D pos, Hy3Node** focused_node);
+
+struct SmartSplitPlacement {
+	Hy3GroupLayout layout;
+	bool insert_before;
+};
+
+static std::optional<SmartSplitPlacement> smartSplitPlacementFor(const Hy3Node& node, const Vector2D& focalPoint) {
+	const auto& box = node.visualBox;
+	if (box.w <= 0 || box.h <= 0) return std::nullopt;
+
+	const auto center = box.pos() + box.size() / 2;
+	const auto delta = focalPoint - center;
+
+	if (std::abs(delta.y) * box.w < std::abs(delta.x) * box.h) {
+		return SmartSplitPlacement{Hy3GroupLayout::SplitH, delta.x < 0};
+	}
+
+	return SmartSplitPlacement{Hy3GroupLayout::SplitV, delta.y < 0};
+}
 
 Hy3Layout::Hy3Layout() {
 	g_hy3Instances.insert(this);
@@ -271,6 +291,56 @@ void Hy3Layout::insertNode(UP<Hy3Node> node_up, std::optional<Vector2D> focalPoi
 		return;
 	}
 
+	static const auto smart_split = ConfigValue<Hyprlang::INT>("plugin:hy3:smart_split");
+	const auto smart_split_placement =
+	    (*smart_split && focalPoint && opening_after) ? smartSplitPlacementFor(*opening_after, *focalPoint) : std::nullopt;
+
+	if (smart_split_placement) {
+		auto& parent_group = opening_into->as_group();
+		if (parent_group.layout != smart_split_placement->layout) {
+			auto iter = parent_group.findChild(*opening_after);
+			if (iter == parent_group.children.end()) {
+				hy3_log(
+				    ERR,
+				    "smart_split target node ({:x}) was not a child of node {:x}",
+				    (uintptr_t) opening_after,
+				    (uintptr_t) opening_into
+				);
+				errorNotif();
+				return;
+			}
+
+			auto* node = node_up.get();
+			auto group_up = Hy3Node::create(smart_split_placement->layout);
+			auto* group_node = group_up.get();
+			auto target_up = parent_group.replaceChild(iter, std::move(group_up));
+			auto& group = group_node->as_group();
+			group.setEphemeral(GroupEphemeralityOption::ForceEphemeral);
+
+			if (smart_split_placement->insert_before) {
+				group.insertChild(std::move(node_up));
+				group.insertChild(std::move(target_up));
+			} else {
+				group.insertChild(std::move(target_up));
+				group.insertChild(std::move(node_up));
+			}
+
+			hy3_log(
+			    LOG,
+			    "smart_split tiled node {:x} inserted {} node {:x} in node {:x}",
+			    (uintptr_t) node,
+			    smart_split_placement->insert_before ? "before" : "after",
+			    (uintptr_t) opening_after,
+			    (uintptr_t) group_node
+			);
+
+			node->markFocused();
+			this->recalcGeometry();
+			this->updateGroupBorderColors();
+			return;
+		}
+	}
+
 	{
 		// clang-format off
 		static const auto at_enable = ConfigValue<Hyprlang::INT>("plugin:hy3:autotile:enable");
@@ -282,7 +352,7 @@ void Hy3Layout::insertNode(UP<Hy3Node> node_up, std::optional<Vector2D> focalPoi
 		this->updateAutotileWorkspaces();
 
 		auto& target_group = opening_into->as_group();
-		if (*at_enable && opening_after != nullptr && target_group.children.size() > 1
+		if (!smart_split_placement && *at_enable && opening_after != nullptr && target_group.children.size() > 1
 		    && target_group.isSplit()
 		    && this->shouldAutotileWorkspace(ws.get()))
 		{
@@ -304,11 +374,11 @@ void Hy3Layout::insertNode(UP<Hy3Node> node_up, std::optional<Vector2D> focalPoi
 	// For mouse drops, determine if we should insert before or after the target node
 	if (focalPoint && opening_after) {
 		auto& parentGroup = opening_into->as_group();
-		bool insert_before = false;
+		bool insert_before = smart_split_placement ? smart_split_placement->insert_before : false;
 
-		if (parentGroup.layout == Hy3GroupLayout::SplitH) {
+		if (!smart_split_placement && parentGroup.layout == Hy3GroupLayout::SplitH) {
 			insert_before = focalPoint->x < opening_after->visualBox.x + opening_after->visualBox.w * 0.5;
-		} else if (parentGroup.layout == Hy3GroupLayout::SplitV) {
+		} else if (!smart_split_placement && parentGroup.layout == Hy3GroupLayout::SplitV) {
 			insert_before = focalPoint->y < opening_after->visualBox.y + opening_after->visualBox.h * 0.5;
 		}
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,6 +42,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	CONF("node_collapse_policy", INT, 2);
 	CONF("group_inset", INT, 10);
 	CONF("tab_first_window", INT, 0);
+	CONF("smart_split", INT, 0);
 
 	// tabs
 	CONF("tabs:height", INT, 22);


### PR DESCRIPTION
## Summary

Adds an optional `plugin:hy3:smart_split` setting for mouse drop insertion.

When enabled, hy3 uses the mouse drop point over the target node's visual box to choose left/right/top/bottom placement, similar to Hyprland Dwindle's `smart_split` behavior.

The option is disabled by default.

## Problem

Mouse drop insertion currently only decides before/after placement inside the target's existing parent layout.

This means a drop on the right or bottom side of a target cannot always express the intended split direction unless the existing parent group already has the matching split layout.

## Behavior

| Drop zone | New split layout | Inserted node position |
|---|---|---|
| Left | `SplitH` | before target |
| Right | `SplitH` | after target |
| Top | `SplitV` | before target |
| Bottom | `SplitV` | after target |

## Implementation

The change is limited to the mouse drop `insertNode()` path.

When `smart_split` is enabled and the cursor position resolves to a target node:

1. Compute the target zone from `opening_after->visualBox`.
2. If the current parent layout already matches, reuse the existing insertion path with the computed before/after position.
3. If the current parent layout differs, replace the target with a new split group and insert both the existing target and the new node into it.
4. Mark the smart-created group as `ForceEphemeral`.

`ForceEphemeral` is important because drag removal currently uses `CollapsePolicy::InvalidOnly`. Without marking smart-created groups ephemeral, a single-child split group can remain after dragging a window back out, which leaves visible `group_inset` spacing.

## Testing

Runtime tested against the official Hyprland `0.54.3` hyprpm pin for hy3.

| Scenario | Result |
|---|---|
| Drop on target left zone | Pass |
| Drop on target right zone | Pass |
| Drop on target top zone | Pass |
| Drop on target bottom zone | Pass |
| Repeated drag/drop after smart insertion | Pass |
| Drag back out of smart-created group | Pass, no stale inset gap |
| Autotile disabled | Pass |
| Autotile enabled | Pass |

CMake configure passes locally on the current `master` branch. Full local build of `master` is blocked by the installed Hyprland `0.54.3` headers missing newer upstream config/render headers required by current hy3 `master`.

## Notes

This PR is independent from the tab containment and single-child tab group fixes in #295 and #296.

`smart_split` only affects mouse drop insertion through `insertNode()`, and only smart-created groups are marked `ForceEphemeral`.
