### PR TITLE
fix(tabs): refresh tab highlight on monitor focus change

### DIFF
--- a/src/TabGroup.cpp
+++ b/src/TabGroup.cpp
@@ -493,8 +493,10 @@ void Hy3TabBar::updateNodeList(std::list<UP<Hy3Node>>& nodes) {
 		auto active = parent_focused && (parent_group.focused_child == node->get() || parent_group.group_focused);
 		entry->setActive(active);
 
-		auto last_monitor = Desktop::focusState()->monitor();
-		entry->setMonitorActive(active && (!last_monitor || (*node)->layout()->monitor() == last_monitor.get()));
+		auto focused_monitor = g_focusedMonitor.lock();
+		auto node_monitor = (*node)->layout()->monitor();
+		auto monitor_active = active && (!focused_monitor || node_monitor == focused_monitor.get());
+		entry->setMonitorActive(monitor_active);
 
 		entry->setUrgent((*node)->isUrgent());
 		entry->setWindowTitle((*node)->getTitle());

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -20,6 +20,11 @@ inline bool g_suppressInsert = false;
 
 inline std::set<Hy3Layout*> g_hy3Instances;
 
+// Tracks the last focused monitor as reported by monitor.focused events.
+// Desktop::focusState()->monitor() is unreliable during event callbacks
+// because it may not yet reflect the new state.
+inline PHLMONITORREF g_focusedMonitor;
+
 inline std::vector<WP<Hy3TabGroup>> g_tabGroups;
 inline std::vector<UP<Hy3TabGroup>> g_destroyingTabGroups;
 
@@ -27,6 +32,7 @@ inline CHyprSignalListener g_renderListener;
 inline CHyprSignalListener g_tickListener;
 inline CHyprSignalListener g_windowTitleListener;
 inline CHyprSignalListener g_urgentListener;
+inline CHyprSignalListener g_monitorFocusListener;
 
 inline Hy3Layout* hy3InstanceForWorkspace(PHLWORKSPACE ws) {
 	if (!ws || !ws->m_space || !ws->m_space->algorithm()) return nullptr;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -141,6 +141,22 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 		node->updateTabBarRecursive();
 	});
 
+	g_monitorFocusListener = Event::bus()->m_events.monitor.focused.listen([](PHLMONITOR monitor) {
+		// Store the focused monitor ourselves since
+		// Desktop::focusState()->monitor() is not yet updated when this fires.
+		g_focusedMonitor = monitor;
+
+		for (auto& mon: g_pCompositor->m_monitors) {
+			for (auto& ws: {mon->m_activeWorkspace, mon->m_activeSpecialWorkspace}) {
+				if (!ws) continue;
+				auto* hy3 = hy3InstanceForWorkspace(ws);
+				if (!hy3) continue;
+				auto* root = hy3->getWorkspaceRootGroup(ws.get());
+				if (root) root->updateDecos();
+			}
+		}
+	});
+
 	registerDispatchers();
 
 	HyprlandAPI::reloadConfig();
@@ -153,6 +169,7 @@ APICALL EXPORT void PLUGIN_EXIT() {
 	g_tickListener.reset();
 	g_windowTitleListener.reset();
 	g_urgentListener.reset();
+	g_monitorFocusListener.reset();
 
 	g_tabGroups.clear();
 	g_destroyingTabGroups.clear();


### PR DESCRIPTION
## Summary

- Fix tab bar active highlight not updating when switching monitors with `focusmonitor` or `hy3:movefocus monitor:`
- When switching away from a monitor, the active tab kept its highlight; when switching back, the highlight was lost until manually moving focus with `movefocus`

## Root cause

`Desktop::focusState()->monitor()` is not yet updated when tab bars are recalculated during a monitor focus change. This caused `active_monitor` to be computed against the stale (previous) monitor value, producing inverted highlight behavior.

## Fix

- Track the focused monitor internally via `g_focusedMonitor`, updated from the `monitor.focused` event
- Use `g_focusedMonitor` instead of `Desktop::focusState()->monitor()` in `updateNodeList()` to compute `active_monitor`
- Trigger `updateDecos()` on all monitors when the focused monitor changes, so both the old and new monitor tab bars refresh correctly