### PR TITLE
fix focus loss when moving window from special workspace without follow

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1004,6 +1004,14 @@ void Hy3Layout::moveNodeToWorkspace(
 
 		node->layout()->recalcGeometry();
 		node->focus(warp, Desktop::FOCUS_REASON_KEYBIND);
+	} else {
+		// When not following, refocus the origin workspace so a remaining node
+		// receives focus.  Without this, moving a window out of a special
+		// workspace causes focus to fall through to the regular workspace below.
+		auto* refocus = this->getWorkspaceFocusedNode(origin);
+		if (refocus != nullptr) {
+			refocus->focus(false, Desktop::FOCUS_REASON_KEYBIND);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

When using `hy3:movetoworkspace` without `,follow` from a special workspace (scratchpad), focus is lost even though the special workspace remains visible with other windows. The focus falls through to the regular workspace below.

## Fix

After extracting a node from the origin workspace via `extractAndMerge` and inserting it into the destination, the `!follow` path now refocuses the origin workspace's focused node. This is consistent with the native `movetoworkspacesilent` dispatcher which handles this correctly.

Closes #299