### PR TITLE
fix(layout): prevent setLayout from mutating Root nodes

### DIFF
--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -160,7 +160,7 @@ void Hy3GroupNode::collapseExpansions() {
 }
 
 void Hy3GroupNode::setLayout(Hy3GroupLayout layout) {
-	if (layout == Hy3GroupLayout::Root) return; // root layout is immutable
+	if (layout == Hy3GroupLayout::Root || this->layout == Hy3GroupLayout::Root) return; // root layout is immutable
 	this->layout = layout;
 
 	if (!isTab()) {


### PR DESCRIPTION
## Summary

- Prevent `setLayout` from modifying a node that already has `Root` layout, making Root layout truly immutable in both directions
- Fixes a crash (SIGABRT) triggered by `changefocus raise` → `changegroup tab` → any focus operation

## Details

See #301 for full analysis, reproduction script, and backtrace.

`setLayout` only prevented changing **to** `Root` layout (`if (layout == Root) return`), but not changing **from** it. When `changeGroupOn` was called on the workspace root group's child, it would call `setLayout(Tabbed)` on the Root node itself, corrupting the tree. Any subsequent `markFocused` call would then crash.

## Change

One-line fix in `Hy3GroupNode::setLayout`:

```cpp
// Before:
if (layout == Hy3GroupLayout::Root) return;
// After:
if (layout == Hy3GroupLayout::Root || this->layout == Hy3GroupLayout::Root) return;
```