### PR TITLE
fix(movetoworkspace): guard node dereference when moving floating window

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1000,8 +1000,10 @@ void Hy3Layout::moveNodeToWorkspace(
 
 		monitor->changeWorkspace(workspace);
 
-		node->layout()->recalcGeometry();
-		node->focus(warp, Desktop::FOCUS_REASON_KEYBIND);
+		if (node != nullptr) {
+			node->layout()->recalcGeometry();
+			node->focus(warp, Desktop::FOCUS_REASON_KEYBIND);
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When a floating window (not managed by hy3) is focused and `hy3:movetoworkspace` is dispatched with `follow=true`, `getWorkspaceFocusedNode` returns `nullptr` because the window has no hy3 node. The code correctly takes the floating-window path and calls `moveWindowToWorkspaceSafe`, but then falls through to the `if (follow)` block which calls `node->layout()` unconditionally, causing a SIGSEGV.

Reproducible with any floating window (e.g. alacritty in float mode):

    hy3:movetoworkspace, <workspace>, follow

## Fix

Add a null check on `node` before dereferencing it in the follow block.  The workspace switch and monitor focus still happen; only the hy3-specific recalc and focus calls are skipped when there is no hy3 node to act on.
