### PR TITLE
fix(movetoworkspace): follow floating window to destination monitor

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -952,9 +952,10 @@ void Hy3Layout::moveNodeToWorkspace(
 		workspace = g_pCompositor->createNewWorkspace(target.id, origin_ws->monitorID(), target.name);
 	}
 
-	if (focused_window != nullptr
-	    && (focused_window_node == nullptr || focused_window->isFullscreen()))
-	{
+	const bool moved_floating =
+	    focused_window != nullptr && (focused_window_node == nullptr || focused_window->isFullscreen());
+
+	if (moved_floating) {
 		g_pHyprRenderer->damageWindow(focused_window);
 		g_pCompositor->moveWindowToWorkspaceSafe(focused_window, workspace);
 	} else {
@@ -1002,7 +1003,7 @@ void Hy3Layout::moveNodeToWorkspace(
 
 		monitor->changeWorkspace(workspace);
 
-		if (node != nullptr) {
+		if (node != nullptr && !moved_floating) {
 			node->layout()->recalcGeometry();
 			node->focus(warp, Desktop::FOCUS_REASON_KEYBIND);
 		} else if (focused_window != nullptr) {

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1008,6 +1008,7 @@ void Hy3Layout::moveNodeToWorkspace(
 		} else if (focused_window != nullptr) {
 			Desktop::focusState()->fullWindowFocus(focused_window, Desktop::FOCUS_REASON_KEYBIND);
 			if (warp) Hy3Layout::warpCursorToBox(focused_window->m_position, focused_window->m_size);
+			Desktop::focusState()->rawMonitorFocus(monitor.lock());
 		}
 	}
 }

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -1002,8 +1002,13 @@ void Hy3Layout::moveNodeToWorkspace(
 
 		monitor->changeWorkspace(workspace);
 
-		node->layout()->recalcGeometry();
-		node->focus(warp, Desktop::FOCUS_REASON_KEYBIND);
+		if (node != nullptr) {
+			node->layout()->recalcGeometry();
+			node->focus(warp, Desktop::FOCUS_REASON_KEYBIND);
+		} else if (focused_window != nullptr) {
+			Desktop::focusState()->fullWindowFocus(focused_window, Desktop::FOCUS_REASON_KEYBIND);
+			if (warp) Hy3Layout::warpCursorToBox(focused_window->m_position, focused_window->m_size);
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

When a focused floating window is moved to another workspace with `follow=true` (e.g. via `hy3:movetoworkspace <ws>,follow`), keyboard focus and active monitor do not reliably follow the window.

Two bugs combine to cause this:

**1. Wrong follow path when a tiled window exists on the origin workspace**

`getWorkspaceFocusedNode(origin)` returns the hy3 node of a tiled window on the origin workspace even though the focused window is floating (and has no hy3 node). The `if (node != nullptr)` branch in the follow block then calls `node->focus()` on that tiled window, stealing both keyboard focus and active monitor from the floating window we just moved.

**2. Monitor focus not explicitly updated**

`fullWindowFocus` and `monitor->changeWorkspace` do not call `rawMonitorFocus` directly. Monitor focus only updates as a side-effect of cursor warping via `simulateMouseMovement`, which is skipped when `misc:mouse_move_focuses_monitor = 0` or the cursor is already within the window bounds.

## Fix

- Introduce `moved_floating` to track whether the dispatched action moved a floating window. When true, skip the `node->focus()` path in the follow block even if `node != nullptr`.
- Call `fullWindowFocus` on the floating window to set keyboard focus with a keybind reason (hard focus), regardless of `input:follow_mouse`.
- Call `rawMonitorFocus` with the destination monitor explicitly so the active monitor is always correct, regardless of cursor position or `misc:mouse_move_focuses_monitor`.

## Reproduction

```
# hyprland.conf — bind mod+o to split-changemonitor
bind = $mod, o, split-changemonitor, +1
```

1. Open a floating terminal on monitor 1 and a tiled window on monitor 2
2. Focus the floating terminal
3. Press `mod+o` repeatedly — before this fix, focus would jump to the tiled window after the first move
