### PR TITLE
Move windows across monitors at root boundary

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -858,14 +858,14 @@ Hy3Node* Hy3Layout::focusMonitor(ShiftDirection direction) {
 	return nullptr;
 }
 
-bool Hy3Layout::shiftMonitor(Hy3Node& node, ShiftDirection direction, bool follow) {
+bool Hy3Layout::shiftMonitor(Hy3Node& node, ShiftDirection direction, bool follow, bool warp) {
 	auto next_monitor = g_pCompositor->getMonitorInDirection(shiftToMathDirection(direction));
 
 	if (next_monitor) {
 		Desktop::focusState()->rawMonitorFocus(next_monitor);
 		auto next_workspace = next_monitor->m_activeWorkspace;
 		if (next_workspace) {
-			moveNodeToWorkspace(node.layout()->workspace().get(), next_workspace->m_name, follow, false);
+			moveNodeToWorkspace(node.layout()->workspace().get(), next_workspace->m_name, follow, warp);
 			return true;
 		}
 	}
@@ -1503,6 +1503,9 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 
 		if (break_parent->is_root()) {
 			if (!shift) return focusMonitor(direction);
+
+			// Moving out of the root group should mirror focus movement and cross monitors.
+			if (shiftMonitor(node, direction, true, true)) return nullptr;
 
 			auto new_layout =
 			    shiftIsVertical(direction) ? Hy3GroupLayout::SplitV : Hy3GroupLayout::SplitH;

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -143,7 +143,7 @@ public:
 	void shiftWindow(const CWorkspace* workspace, ShiftDirection, bool once, bool visible);
 	void shiftFocus(const CWorkspace* workspace, ShiftDirection, bool visible, bool warp);
 	void toggleFocusLayer(const CWorkspace* workspace, bool warp);
-	bool shiftMonitor(Hy3Node&, ShiftDirection, bool follow);
+	bool shiftMonitor(Hy3Node&, ShiftDirection, bool follow, bool warp);
 	Hy3Node* focusMonitor(ShiftDirection);
 
 	void warpCursor();


### PR DESCRIPTION
## Summary
- make `hy3:movewindow` try the adjacent monitor when moving out of the root group
- follow focus to the moved window and warp the cursor to it, avoiding focus-follows-mouse switching back to the old monitor
- keep the existing split-wrapping fallback when there is no monitor in that direction

## Why
`hy3:movefocus` already crosses monitor boundaries via `focusMonitor(direction)`, but `hy3:movewindow` only wrapped the root node into a new split when it reached the workspace root boundary. On multi-monitor setups this made directional window moves stop at the monitor edge.

When `input:follow_mouse` is enabled, moving the window without warping the cursor can also leave the pointer on the old monitor and cause follow-up actions (for example closing with a keybind) to affect a different window. The monitor-crossing move now forwards the warp flag to `moveNodeToWorkspace`.

## Testing
- Built locally with CMake/Ninja
- Replaced the hyprpm-loaded plugin locally and verified `hy3:movewindow r` moves a test window from DP-1/workspace 99 to DP-2/workspace 3
