### PR TITLE
feat: vertical tab (stack) layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,11 +342,11 @@ plugin {
 ```
 
 ### Dispatcher list
- - `hy3:makegroup, <h | v | opposite | tab>, [toggle], [ephemeral | force_ephemeral]` - make a vertical / horizontal split or tab group
+ - `hy3:makegroup, <h | v | opposite | tab | stack>, [toggle], [ephemeral | force_ephemeral]` - make a vertical / horizontal split or tab/stack group
    - `toggle` - if the focused node is the only child of its parent, which is of the type specified, the node's parent will be removed.
    - `ephemeral` - the group will be removed once it contains only one node. does not affect existing groups.
    - `force_ephemeral` - same as ephemeral, but converts existing single windows groups.
- - `hy3:changegroup, <h | v | tab | untab | toggletab | opposite>` - change the group the node belongs to, to a different layout
+ - `hy3:changegroup, <h | v | tab | stack | untab | toggletab | opposite>` - change the group the node belongs to, to a different layout
    - `untab` will untab the group if it was previously tabbed
    - `toggletab` will untab if group is tabbed, and tab if group is untabbed
    - `opposite` will toggle between horizontal and vertical layouts if the group is not tabbed.
@@ -373,8 +373,8 @@ plugin {
    - `tabnode` - raise focus to the nearest node under the tab
  - `hy3:togglefocuslayer, [nowarp]` - toggle focus between tiled and floating layers
    - `nowarp` - do not warp the mouse to the newly focused window
- - `hy3:focustab, [l | r | left | right | index, <index>], [prioritize_hovered | require_hovered], [wrap]`
-   - `l | r | left | right` - direction to change focus towards
+ - `hy3:focustab, [l | r | u | d | left | right | up | down | index, <index>], [prioritize_hovered | require_hovered], [wrap]`
+   - `l | r | u | d | left | right | up | down` - direction to change focus towards
    - `index, <index>` - select the `index`th tab
    - `prioritize_hovered` - prioritize the tab group under the mouse when multiple are stacked. use the lowest group if none is under the mouse.
    - `require_hovered` - affect the tab group under the mouse. do nothing if none are hovered.
@@ -401,12 +401,12 @@ local hy3 = hl.plugin.hy3
 -- all factories return dispatcher functions and dispatchers return no values
 -- option tables are optional except for focus_tab
 
-hy3.make_group("h" | "v" | "tab" | "opposite", {
+hy3.make_group("h" | "v" | "tab" | "stack" | "opposite", {
 	toggle = true | false,              -- default: false
 	ephemeral = true | false | "force", -- default: false
 })
 
-hy3.change_group("h" | "v" | "tab" | "untab" | "toggletab" | "opposite")
+hy3.change_group("h" | "v" | "tab" | "stack" | "untab" | "toggletab" | "opposite")
 
 hy3.set_ephemeral(true | false | "true" | "false")
 
@@ -435,7 +435,7 @@ hy3.change_focus("top" | "bottom" | "raise" | "lower" | "tab" | "tabnode")
 
 -- direction and index are mutually exclusive
 hy3.focus_tab({
-	direction = "l" | "r" | "left" | "right",
+	direction = "l" | "r" | "u" | "d" | "left" | "right" | "up" | "down",
 	mouse = "ignore" | "prioritize_hovered" | "require_hovered", -- default: "ignore"
 	wrap = true | false, -- default: false
 })

--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -561,6 +561,7 @@ Config::ErrorResult Hy3Layout::layoutMsg(const std::string_view& sv) {
 				break;
 			case Hy3GroupLayout::Root: break;
 			case Hy3GroupLayout::Tabbed: break;
+			case Hy3GroupLayout::Stack: break;
 			}
 		}
 	}
@@ -1067,8 +1068,6 @@ Hy3Node* findTabBarAt(Hy3Node& node, Vector2D pos, Hy3Node** focused_node) {
 	auto workspace_rule = Config::workspaceRuleMgr()->getWorkspaceRuleFor(node.layout()->workspace());
 	auto gaps_in = workspace_rule.and_then([](auto r) { return r.m_gapsIn; }).value_or(*sc<Config::CCssGapData*>(p_gaps_in.ptr()));
 
-	auto inset = *tab_bar_height + *tab_bar_padding + gaps_in.m_top;
-
 	if (node.is_group()) {
 		if (node.hidden) return nullptr;
 		// note: tab bar clicks ignore animations
@@ -1079,19 +1078,49 @@ Hy3Node* findTabBarAt(Hy3Node& node, Vector2D pos, Hy3Node** focused_node) {
 		auto& group = node.as_group();
 
 		if (group.isTab() && group.tab_bar) {
-			if (pos.y < node.visualBox.y + inset) {
-				auto& children = group.children;
-				auto& tab_bar = *group.tab_bar.get();
+			auto& children = group.children;
+			auto& tab_bar = *group.tab_bar.get();
+			auto size = tab_bar.size->value();
+			auto child_iter = children.begin();
 
-				auto size = tab_bar.size->value();
-				auto x = pos.x - tab_bar.pos->value().x;
-				auto child_iter = children.begin();
+			if (group.layout == Hy3GroupLayout::Tabbed) {
+				auto inset = *tab_bar_height + *tab_bar_padding + gaps_in.m_top;
+
+				if (pos.y < node.visualBox.y + inset) {
+					auto x = pos.x - tab_bar.pos->value().x;
+
+					for (auto& tab: tab_bar.bar.entries) {
+						if (child_iter == children.end()) break;
+
+						if (x > tab.offset->value() * size.x
+						    && x < (tab.offset->value() + tab.width->value()) * size.x)
+						{
+							*focused_node = child_iter->get();
+							return &node;
+						}
+
+						child_iter = std::next(child_iter);
+					}
+				}
+			} else if (group.layout == Hy3GroupLayout::Stack) {
+				auto child_count = group.children.size();
+				auto total_bar_height = child_count * *tab_bar_height + (child_count > 1 ? (child_count - 1) * *tab_bar_padding : 0);
+				auto inset = total_bar_height + *tab_bar_padding + gaps_in.m_top;
+
+				if (pos.y >= node.visualBox.y + inset) {
+					if (group.focused_child != nullptr) {
+						return findTabBarAt(*group.focused_child, pos, focused_node);
+					}
+					return nullptr;
+				}
+
+				auto y = pos.y - tab_bar.pos->value().y;
 
 				for (auto& tab: tab_bar.bar.entries) {
 					if (child_iter == children.end()) break;
 
-					if (x > tab.offset->value() * size.x
-					    && x < (tab.offset->value() + tab.width->value()) * size.x)
+					if (y > tab.offset->value() * size.y
+					    && y < (tab.offset->value() + tab.width->value()) * size.y)
 					{
 						*focused_node = child_iter->get();
 						return &node;
@@ -1185,14 +1214,24 @@ hastab:
 		} else {
 			auto node_iter = group.findChild(*group.focused_child);
 			if (node_iter == children.end()) return;
-			if (target == TabFocus::Left) {
+
+			bool go_backward = false;
+			bool go_forward = false;
+
+			if (target == TabFocus::Left || target == TabFocus::Up) {
+				go_backward = true;
+			} else if (target == TabFocus::Right || target == TabFocus::Down) {
+				go_forward = true;
+			}
+
+			if (go_backward) {
 				if (node_iter == children.begin()) {
 					if (wrap_scroll) node_iter = std::prev(children.end());
 					else return;
 				} else node_iter = std::prev(node_iter);
 
 				tab_focused_node = node_iter->get();
-			} else {
+			} else if (go_forward) {
 				if (node_iter == std::prev(children.end())) {
 					if (wrap_scroll) node_iter = children.begin();
 					else return;
@@ -1458,6 +1497,8 @@ bool shiftIsVertical(ShiftDirection direction) {
 
 bool shiftMatchesLayout(Hy3GroupLayout layout, ShiftDirection direction) {
 	if (layout == Hy3GroupLayout::Root) return false;
+	if (layout == Hy3GroupLayout::Tabbed) return !shiftIsVertical(direction);
+	if (layout == Hy3GroupLayout::Stack) return shiftIsVertical(direction);
 	return (layout == Hy3GroupLayout::SplitV && shiftIsVertical(direction))
 	    || (layout != Hy3GroupLayout::SplitV && !shiftIsVertical(direction));
 }

--- a/src/Hy3Layout.hpp
+++ b/src/Hy3Layout.hpp
@@ -60,6 +60,8 @@ enum class TabFocus {
 	MouseLocation,
 	Left,
 	Right,
+	Up,
+	Down,
 	Index,
 };
 

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -401,6 +401,7 @@ void Hy3Node::recalcSizePosRecursive(CBox offsets, bool no_animation) {
 		constraint = tsize.y - (child_count > 1 ? (child_count - 1) * inter_gap : 0);
 		break;
 	case Hy3GroupLayout::Tabbed:
+	case Hy3GroupLayout::Stack:
 	case Hy3GroupLayout::Root: break;
 	}
 
@@ -469,6 +470,23 @@ void Hy3Node::recalcSizePosRecursive(CBox offsets, bool no_animation) {
 			// Tab bar makes child non-edge on top
 			child_offsets.x = offsets.x;
 			child_offsets.y = offsets.y + tab_offset;
+			child_offsets.w = offsets.w;
+			child_offsets.h = offsets.h;
+
+			child->recalcSizePosRecursive(child_offsets, no_animation);
+			break;
+		}
+		case Hy3GroupLayout::Stack: {
+			double entry_height = (double)*tab_bar_height;
+			double total_bar_height = child_count * entry_height + (child_count > 1 ? (child_count - 1) * *tab_bar_padding : 0);
+			double stack_offset = total_bar_height + (double)*tab_bar_padding;
+
+			child->visualBox = CBox(tpos.x, tpos.y + stack_offset, tsize.x, tsize.y - stack_offset);
+			child->hidden = this->hidden || expand_focused || group.focused_child != child.get();
+
+			// Stack bar makes child on top non-edge
+			child_offsets.x = offsets.x;
+			child_offsets.y = offsets.y + stack_offset;
 			child_offsets.w = offsets.w;
 			child_offsets.h = offsets.h;
 
@@ -553,6 +571,7 @@ std::string Hy3Node::getTitle() {
 		case Hy3GroupLayout::SplitH: title = "[H] "; break;
 		case Hy3GroupLayout::SplitV: title = "[V] "; break;
 		case Hy3GroupLayout::Tabbed: title = "[T] "; break;
+		case Hy3GroupLayout::Stack: title = "[S] "; break;
 		}
 
 		if (group.focused_child == nullptr) {
@@ -656,6 +675,7 @@ std::string Hy3Node::debugNode() {
 		case Hy3GroupLayout::SplitH: buf << "splith"; break;
 		case Hy3GroupLayout::SplitV: buf << "splitv"; break;
 		case Hy3GroupLayout::Tabbed: buf << "tabs"; break;
+		case Hy3GroupLayout::Stack: buf << "stack"; break;
 		}
 
 		buf << "] size ratio: ";

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -20,6 +20,7 @@ enum class Hy3GroupLayout {
 	SplitH,
 	SplitV,
 	Tabbed,
+	Stack,
 };
 
 enum class Hy3NodeType {
@@ -143,7 +144,7 @@ struct Hy3GroupNode : Hy3Node {
 	~Hy3GroupNode() override = default;
 
 	bool isSplit() const { return layout == Hy3GroupLayout::SplitH || layout == Hy3GroupLayout::SplitV; }
-	bool isTab() const { return layout == Hy3GroupLayout::Tabbed; }
+	bool isTab() const { return layout == Hy3GroupLayout::Tabbed || layout == Hy3GroupLayout::Stack; }
 
 	bool hasChild(Hy3Node& child);
 	void collapseExpansions();

--- a/src/TabGroup.cpp
+++ b/src/TabGroup.cpp
@@ -607,9 +607,21 @@ Hy3TabGroup::Hy3TabGroup(Hy3Node& node) {
 
 void Hy3TabGroup::updateWithGroup(Hy3Node& node, bool warp) {
 	static const auto bar_height = CConfigValue<Config::INTEGER>("plugin:hy3:tabs:height");
+	static const auto bar_padding = CConfigValue<Config::INTEGER>("plugin:hy3:tabs:padding");
 
 	auto tpos = node.visualBox.pos();
-	auto tsize = Vector2D(node.visualBox.w, *bar_height);
+	auto& group = node.as_group();
+	this->layout = group.layout;
+	Vector2D tsize;
+
+	if (group.layout == Hy3GroupLayout::Tabbed) {
+		tsize = Vector2D(node.visualBox.w, *bar_height);
+	} else if (group.layout == Hy3GroupLayout::Stack) {
+		auto child_count = group.children.size();
+		double entry_h = (double)*bar_height;
+		double total_h = child_count * entry_h + (child_count > 1 ? (child_count - 1) * *bar_padding : 0);
+		tsize = Vector2D(node.visualBox.w, total_h);
+	}
 
 	this->hidden = node.hidden;
 	if (this->pos->goal() != tpos) {
@@ -819,13 +831,27 @@ void Hy3TabGroup::renderTabBar() {
 	                  * (valid(this->workspace) ? this->workspace->m_alpha->value() : 1.0);
 
 	auto render_entry = [&](Hy3TabBarEntry& entry) {
-		Vector2D entry_pos = {
-		    (box.x + (entry.offset->value() * box.w) + (*padding * 0.5)) * scale,
-		    scaledBox.y
-		        + ((entry.vertical_pos->value() * (box.h + *padding) * scale)
-		           * (*enter_from_top ? -1 : 1)),
-		};
-		Vector2D entry_size = {((entry.width->value() * box.w) - *padding) * scale, scaledBox.h};
+		Vector2D entry_pos;
+		Vector2D entry_size;
+
+		if (this->layout == Hy3GroupLayout::Tabbed) {
+			entry_pos = Vector2D(
+			    (box.x + (entry.offset->value() * box.w) + (*padding * 0.5)) * scale,
+			    scaledBox.y
+			        + ((entry.vertical_pos->value() * (box.h + *padding) * scale)
+			           * (*enter_from_top ? -1 : 1))
+			);
+			entry_size = Vector2D(((entry.width->value() * box.w) - *padding) * scale, scaledBox.h);
+		} else if (this->layout == Hy3GroupLayout::Stack) {
+			entry_pos = Vector2D(
+			    scaledBox.x,
+			    (box.y + (entry.offset->value() * box.h) + (*padding * 0.5)) * scale
+			        + ((entry.vertical_pos->value() * (box.h + *padding) * scale)
+			           * (*enter_from_top ? -1 : 1))
+			);
+			entry_size = Vector2D(scaledBox.w, ((entry.width->value() * box.h) - *padding) * scale);
+		}
+
 		if (entry_size.x < 0 || entry_size.y < 0 || fade_opacity == 0.0) return;
 
 		CBox box = {
@@ -912,6 +938,7 @@ void findOverlappingWindows(Hy3Node& node, float height, std::vector<PHLWINDOWRE
 			}
 			break;
 		case Hy3GroupLayout::Tabbed:
+		case Hy3GroupLayout::Stack:
 			// assume the height of that node's tab bar already pushes it out of range
 			break;
 		}

--- a/src/TabGroup.hpp
+++ b/src/TabGroup.hpp
@@ -141,6 +141,7 @@ public:
 	PHLWINDOW target_window = nullptr;
 	PHLWORKSPACE workspace = nullptr;
 	bool hidden = false;
+	Hy3GroupLayout layout;
 	Hy3TabBar bar;
 	PHLANIMVAR<Vector2D> pos;
 	PHLANIMVAR<Vector2D> size;

--- a/src/dispatchers.cpp
+++ b/src/dispatchers.cpp
@@ -88,6 +88,7 @@ static std::optional<SMakeGroupAction> parseMakeGroupArg(std::string_view arg) {
 	if (arg == "h") return SMakeGroupAction { .layout = Hy3GroupLayout::SplitH };
 	if (arg == "v") return SMakeGroupAction { .layout = Hy3GroupLayout::SplitV };
 	if (arg == "tab") return SMakeGroupAction { .layout = Hy3GroupLayout::Tabbed };
+	if (arg == "stack") return SMakeGroupAction { .layout = Hy3GroupLayout::Stack };
 	if (arg == "opposite") return SMakeGroupAction { .opposite = true };
 	return {};
 }
@@ -96,7 +97,7 @@ static SMakeGroupAction luaMakeGroupActionArg(lua_State* L, int idx, const char*
 	auto value = luaStringArg(L, idx, fn, "layout");
 	auto action = parseMakeGroupArg(value);
 	if (!action)
-		luaL_error(L, "%s: invalid layout '%s' (expected h/v/tab/opposite)", fn, value.c_str());
+		luaL_error(L, "%s: invalid layout '%s' (expected h/v/tab/stack/opposite)", fn, value.c_str());
 	return *action;
 }
 
@@ -197,6 +198,7 @@ enum class ChangeGroupAction {
 	SplitH,
 	SplitV,
 	Tabbed,
+	Stack,
 	Untab,
 	ToggleTab,
 	Opposite,
@@ -206,6 +208,7 @@ static std::optional<ChangeGroupAction> parseChangeGroupArg(std::string_view arg
 	if (arg == "h") return ChangeGroupAction::SplitH;
 	if (arg == "v") return ChangeGroupAction::SplitV;
 	if (arg == "tab") return ChangeGroupAction::Tabbed;
+	if (arg == "stack") return ChangeGroupAction::Stack;
 	if (arg == "untab") return ChangeGroupAction::Untab;
 	if (arg == "toggletab") return ChangeGroupAction::ToggleTab;
 	if (arg == "opposite") return ChangeGroupAction::Opposite;
@@ -216,7 +219,7 @@ static ChangeGroupAction luaChangeGroupActionArg(lua_State* L, int idx, const ch
 	auto value = luaStringArg(L, idx, fn, "layout");
 	auto action = parseChangeGroupArg(value);
 	if (!action)
-		luaL_error(L, "%s: invalid layout '%s' (expected h/v/tab/untab/toggletab/opposite)", fn, value.c_str());
+		luaL_error(L, "%s: invalid layout '%s' (expected h/v/tab/stack/untab/toggletab/opposite)", fn, value.c_str());
 	return *action;
 }
 
@@ -234,6 +237,9 @@ static SDispatchResult changeGroup(ChangeGroupAction action) {
 		break;
 	case ChangeGroupAction::Tabbed:
 		hy3->changeGroupOnWorkspace(ws.get(), Hy3GroupLayout::Tabbed);
+		break;
+	case ChangeGroupAction::Stack:
+		hy3->changeGroupOnWorkspace(ws.get(), Hy3GroupLayout::Stack);
 		break;
 	case ChangeGroupAction::Untab:
 		hy3->untabGroupOnWorkspace(ws.get());
@@ -632,8 +638,10 @@ static int luaFocusTab(lua_State* L) {
 			return luaL_error(L, "%s: expected either 'direction' or 'index'", FN);
 		if (*direction == "l" || *direction == "left") focus = TabFocus::Left;
 		else if (*direction == "r" || *direction == "right") focus = TabFocus::Right;
+		else if (*direction == "u" || *direction == "up") focus = TabFocus::Up;
+		else if (*direction == "d" || *direction == "down") focus = TabFocus::Down;
 		else
-			return luaL_error(L, "%s: invalid direction '%s' (expected left/right)", FN, direction->c_str());
+			return luaL_error(L, "%s: invalid direction '%s' (expected left/right/up/down)", FN, direction->c_str());
 	}
 
 	auto mouse = TabFocusMousePriority::Ignore;
@@ -674,6 +682,8 @@ static SDispatchResult dispatch_focustab(std::string value) {
 
 	if (args[i] == "l" || args[i] == "left") focus = TabFocus::Left;
 	else if (args[i] == "r" || args[i] == "right") focus = TabFocus::Right;
+	else if (args[i] == "u" || args[i] == "up") focus = TabFocus::Up;
+	else if (args[i] == "d" || args[i] == "down") focus = TabFocus::Down;
 	else if (args[i] == "index") {
 		i++;
 		focus = TabFocus::Index;


### PR DESCRIPTION
Adds a vertical stack layout which works like tabs, but stacks vertically instead: https://github.com/outfoxxed/hy3/discussions/235

<img width="690" height="83" alt="image" src="https://github.com/user-attachments/assets/71d15a23-8ea4-4a50-9957-9c2e21cfbd05" />


This layout is nice to use when you're constrained horizontally, and also nice because monitors are wider than they are taller - if you only use 'focus right / focus left' (i.e., when switching to a monitor to the side), you end up going into tabs you didn't intend to. Using stacks removes that issue and makes the content of the tabs easier to check, since your eyes don't have to go searching across your screen.

One thing I'm not sure about is whether any of the dispatchers should include this (e.g., `toggletab`) - that's how I switched between tabs in sway/i3 (`bindsym $mod+s layout toggle stacking tabbed`), but using it on its own with changegroup/makegroup is probably good enough.

Disclosure: Most of this code was written by an LLM, but I reviewed each line, tested it thoroughly, fixed a couple of regressions, etc. All the things that would work with a regular tab also work with stacked tabs.