### PR TITLE
fix: tab bars rendered in wrong orientation on rotated monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # Upcoming
 
 - Fix mouse up+left mouse resize
+- Fix tab bars rendering in the wrong orientation on rotated monitors
 
 # hl0.56.0 and before
 

--- a/src/render.cpp
+++ b/src/render.cpp
@@ -1,7 +1,6 @@
 #include "render.hpp"
 
 #include <GLES2/gl2.h>
-#include <hyprland/src/helpers/math/Math.hpp>
 #include <hyprland/src/render/OpenGL.hpp>
 #include <hyprland/src/render/gl/GLTexture.hpp>
 #include <hyprland/src/render/Shader.hpp>
@@ -34,13 +33,7 @@ void Hy3Render::renderTab(
 	const auto& monitorSize = rdata.pMonitor->m_transformedSize;
 	auto monitorBox = CBox {Vector2D(), monitorSize};
 
-	const auto monitor_inverted = Math::wlTransformToHyprutils(
-			Math::invertTransform(g_pHyprRenderer->m_renderData.pMonitor->m_transform)
-	);
-
-	Hyprutils::Math::eTransform transform = monitor_inverted;
-
-	auto glMatrix = g_pHyprRenderer->projectBoxToTarget(monitorBox, transform);
+	auto glMatrix = g_pHyprRenderer->projectBoxToTarget(monitorBox, Hyprutils::Math::HYPRUTILS_TRANSFORM_NORMAL);
 
 	g_pHyprOpenGL->useShader(shader.program);
 


### PR DESCRIPTION
hi,

since development on #314 seems stalled, i wanted to give it a try. I have very little experience with cpp but otherwise a lot of development experience and used github copilot to make the fix. Of course i tested the changes locally, since i don't want to submit slop anywhere, and the issue is fixed on my computer with a 90° rotated monitor.

Since the issue existed before (#182) i assumed that some later change reintroduced it. Copilot found the regression introduced in 76010d9 and the fix looks reasonable and simple to me. here is copilots explanation of the change:

> projectBoxToTarget internally composes getScaleMatrix() with targetProjection.projectBox(), where targetProjection (m_projMatrix) already contains the monitor's WL transform rotation. Passing monitor_inverted as the transform parameter applies the inverse rotation inside projectBox(), cancelling out the rotation already present in m_projMatrix — reproducing the double-rotation bug that was originally fixed in 0525702.
> Pass HYPRUTILS_TRANSFORM_NORMAL instead, leaving m_projMatrix's rotation intact, which is equivalent to the pre-refactor fix of rdata.projection * monitorProjection.projectBox(monitorBox, NORMAL).

I hope this makes sense and the change is reasonable and i'm not wasting anyone's time.

---
Fixes #314.