### PR TITLE
fix: make focused_child more robust by using WP

### DIFF
--- a/src/Hy3Layout.cpp
+++ b/src/Hy3Layout.cpp
@@ -125,8 +125,8 @@ Hy3Layout::Hy3Layout() {
 		    if (!tab_node) return;
 
 		    while (focus->is_group() && !focus->as_group().group_focused
-		           && focus->as_group().focused_child != nullptr)
-			    focus = focus->as_group().focused_child;
+		           && focus->as_group().focused_child.get() != nullptr)
+			    focus = focus->as_group().focused_child.get();
 
 		    focus->focus(false, Desktop::FOCUS_REASON_CLICK);
 		    g_pInputManager->simulateMouseMovement();
@@ -1035,8 +1035,8 @@ void Hy3Layout::changeFocus(const CWorkspace* workspace, FocusShift shift) {
 		this->updateGroupBorderColors();
 		return;
 	case FocusShift::Lower:
-		if (node->is_group() && node->as_group().focused_child != nullptr)
-			node->as_group().focused_child->focus(false, Desktop::FOCUS_REASON_KEYBIND);
+		if (node->is_group() && node->as_group().focused_child.get() != nullptr)
+			node->as_group().focused_child.get()->focus(false, Desktop::FOCUS_REASON_KEYBIND);
 		this->updateGroupBorderColors();
 		return;
 	case FocusShift::Tab:
@@ -1060,8 +1060,8 @@ void Hy3Layout::changeFocus(const CWorkspace* workspace, FocusShift shift) {
 	}
 
 bottom:
-	while (node->is_group() && node->as_group().focused_child != nullptr) {
-		node = node->as_group().focused_child;
+	while (node->is_group() && node->as_group().focused_child.get() != nullptr) {
+		node = node->as_group().focused_child.get();
 	}
 
 	node->focus(false, Desktop::FOCUS_REASON_KEYBIND);
@@ -1113,8 +1113,8 @@ Hy3Node* findTabBarAt(Hy3Node& node, Vector2D pos, Hy3Node** focused_node) {
 				}
 			}
 
-			if (group.focused_child != nullptr) {
-				return findTabBarAt(*group.focused_child, pos, focused_node);
+			if (group.focused_child.get() != nullptr) {
+				return findTabBarAt(*group.focused_child.get(), pos, focused_node);
 			}
 		} else {
 			for (auto& child: group.children) {
@@ -1177,7 +1177,7 @@ void Hy3Layout::focusTab(
 hastab:
 	if (target != TabFocus::MouseLocation) {
 		auto& group = tab_node->as_group();
-		if (group.focused_child == nullptr || group.children.size() < 2) return;
+		if (group.focused_child.get() == nullptr || group.children.size() < 2) return;
 
 		auto& children = group.children;
 		if (target == TabFocus::Index) {
@@ -1195,7 +1195,7 @@ hastab:
 			return;
 		cont:;
 		} else {
-			auto node_iter = group.findChild(*group.focused_child);
+			auto node_iter = group.findChild(*group.focused_child.get());
 			if (node_iter == children.end()) return;
 			if (target == TabFocus::Left) {
 				if (node_iter == children.begin()) {
@@ -1217,8 +1217,8 @@ hastab:
 
 	auto* focus = tab_focused_node;
 	while (focus->is_group() && !focus->as_group().group_focused
-	       && focus->as_group().focused_child != nullptr)
-		focus = focus->as_group().focused_child;
+	       && focus->as_group().focused_child.get() != nullptr)
+		focus = focus->as_group().focused_child.get();
 
 	focus->focus(false, Desktop::FOCUS_REASON_KEYBIND);
 	this->recalcGeometry();
@@ -1272,7 +1272,7 @@ void Hy3Layout::expand(
 			node->as_group().expand_focused = ExpandFocusType::Stack;
 
 		auto& group = node->parent->as_group();
-		group.focused_child = node;
+		group.focused_child = node->self;
 		group.expand_focused = ExpandFocusType::Latch;
 
 		this->recalcGeometry();
@@ -1290,8 +1290,8 @@ void Hy3Layout::expand(
 			auto& group = node->as_group();
 
 			group.expand_focused = ExpandFocusType::NotExpanded;
-			if (group.focused_child->is_group())
-				group.focused_child->as_group().expand_focused = ExpandFocusType::Latch;
+			if (group.focused_child.get()->is_group())
+				group.focused_child.get()->as_group().expand_focused = ExpandFocusType::Latch;
 
 			this->recalcGeometry();
 		}
@@ -1403,7 +1403,7 @@ bool Hy3Layout::shouldRenderSelected(const CWindow* window) {
 	if (Desktop::focusState()->window()) return false;
 
 	auto* root = this->getWorkspaceRootGroup(window->m_workspace.get());
-	if (root == nullptr || root->as_group().focused_child == nullptr) return false;
+	if (root == nullptr || root->as_group().focused_child.get() == nullptr) return false;
 	auto* focused = &root->getFocusedNode();
 
 	switch (focused->type()) {
@@ -1576,14 +1576,14 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 				bool shift_after = false;
 
 				if (!shift && group_data.isTab()
-				    && group_data.focused_child != nullptr)
+				    && group_data.focused_child.get() != nullptr)
 				{
-					iter = group_data.findChild(*group_data.focused_child);
+					iter = group_data.findChild(*group_data.focused_child.get());
 				} else if (visible && group_data.isTab()
-				           && group_data.focused_child != nullptr)
+				           && group_data.focused_child.get() != nullptr)
 				{
 					// if the group is tabbed and we're going by visible nodes, jump to the current entry
-					iter = group_data.findChild(*group_data.focused_child);
+					iter = group_data.findChild(*group_data.focused_child.get());
 					shift_after = true;
 				} else if (shiftMatchesLayout(group_data.layout, direction)
 				           || (visible && group_data.isTab()))
@@ -1596,8 +1596,8 @@ Hy3Node* Hy3Layout::shiftOrGetFocus(
 						shift_after = true;
 					}
 				} else {
-					if (group_data.focused_child != nullptr) {
-						iter = group_data.findChild(*group_data.focused_child);
+					if (group_data.focused_child.get() != nullptr) {
+						iter = group_data.findChild(*group_data.focused_child.get());
 						shift_after = true;
 					} else {
 						iter = group_data.children.begin();

--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -75,7 +75,7 @@ auto Hy3GroupNode::findChild(Hy3Node& child) -> std::list<UP<Hy3Node>>::iterator
 
 void Hy3GroupNode::insertChild(std::list<UP<Hy3Node>>::iterator pos, UP<Hy3Node> child) {
 	child->parent = this->self;
-	if (focused_child == nullptr) focused_child = child.get();
+	if (focused_child.get() == nullptr) focused_child = child->self;
 	children.insert(pos, std::move(child));
 	if (ephemeral == Ephemeral::Staged && children.size() >= 2)
 		ephemeral = Ephemeral::Active;
@@ -89,13 +89,13 @@ UP<Hy3Node> Hy3GroupNode::extractChildRaw(std::list<UP<Hy3Node>>::iterator it) {
 	auto* child_ptr = it->get();
 
 	// Fix focused_child if we're extracting it
-	if (focused_child == child_ptr) {
+	if (focused_child.get() == child_ptr) {
 		if (children.size() <= 1) {
-			focused_child = nullptr;
+			focused_child.reset();
 		} else if (it == children.begin()) {
-			focused_child = std::next(it)->get();
+			focused_child = (*std::next(it))->self;
 		} else {
-			focused_child = std::prev(it)->get();
+			focused_child = (*std::prev(it))->self;
 		}
 	}
 
@@ -140,7 +140,7 @@ UP<Hy3Node> Hy3GroupNode::extractChild(Hy3Node& child) {
 UP<Hy3Node> Hy3GroupNode::replaceChild(std::list<UP<Hy3Node>>::iterator it, UP<Hy3Node> replacement) {
 	replacement->parent = this->self;
 	replacement->size_ratio = (*it)->size_ratio;
-	if (focused_child == it->get()) focused_child = replacement.get();
+	if (focused_child.get() == it->get()) focused_child = replacement->self;
 	auto old = std::exchange(*it, std::move(replacement));
 	old->size_ratio = 1.0;
 	old->parent.reset();
@@ -151,12 +151,12 @@ void Hy3GroupNode::collapseExpansions() {
 	if (this->expand_focused == ExpandFocusType::NotExpanded) return;
 	this->expand_focused = ExpandFocusType::NotExpanded;
 
-	Hy3Node* node = this->focused_child;
+	Hy3Node* node = this->focused_child.get();
 
-	while (node->is_group() && node->as_group().expand_focused == ExpandFocusType::Stack) {
+	while (node != nullptr && node->is_group() && node->as_group().expand_focused == ExpandFocusType::Stack) {
 		auto& group = node->as_group();
 		group.expand_focused = ExpandFocusType::NotExpanded;
-		node = group.focused_child;
+		node = group.focused_child.get();
 	}
 }
 
@@ -273,7 +273,7 @@ void Hy3Node::markFocused() {
 
 	for (auto& ancestor: this->ancestors()) {
 		auto& group = ancestor.parent->as_group();
-		group.focused_child = &ancestor;
+		group.focused_child = ancestor.self;
 		group.group_focused = false;
 	}
 
@@ -286,12 +286,12 @@ Hy3Node& Hy3Node::getFocusedNode(bool ignore_group_focus, bool stop_at_expanded)
 	case Hy3NodeType::Group: {
 		auto& group = this->as_group();
 
-		if (group.focused_child == nullptr || (!ignore_group_focus && group.group_focused)
+		if (group.focused_child.get() == nullptr || (!ignore_group_focus && group.group_focused)
 		    || (stop_at_expanded && group.expand_focused != ExpandFocusType::NotExpanded))
 		{
 			return *this;
 		} else {
-			return group.focused_child->getFocusedNode(ignore_group_focus, stop_at_expanded);
+			return group.focused_child.get()->getFocusedNode(ignore_group_focus, stop_at_expanded);
 		}
 	}
 	}
@@ -301,7 +301,7 @@ Hy3Node& Hy3Node::getFocusedNode(bool ignore_group_focus, bool stop_at_expanded)
 bool Hy3Node::isIndirectlyFocused() {
 	for (auto& node: this->ancestors()) {
 		auto& group = node.parent->as_group();
-		if (!group.group_focused && group.focused_child != &node) return false;
+		if (!group.group_focused && group.focused_child.get() != &node) return false;
 	}
 
 	return true;
@@ -357,19 +357,20 @@ void Hy3Node::recalcSizePosRecursive(CBox offsets, bool no_animation) {
 	auto expand_focused = group.expand_focused != ExpandFocusType::NotExpanded;
 	bool directly_contains_expanded =
 	    expand_focused
-	    && (group.focused_child->is_target()
-	        || group.focused_child->as_group().expand_focused == ExpandFocusType::NotExpanded);
+	    && (group.focused_child.get() != nullptr)
+	    && (group.focused_child.get()->is_target()
+	        || group.focused_child.get()->as_group().expand_focused == ExpandFocusType::NotExpanded);
 
 	auto child_count = group.children.size();
 
 	// Latch/expanded: expanded node covers full parent area with parent offsets
 	if (group.expand_focused == ExpandFocusType::Latch) {
-		auto* expanded_node = group.focused_child;
+		auto* expanded_node = group.focused_child.get();
 
 		while (expanded_node != nullptr && expanded_node->is_group()
 		       && expanded_node->as_group().expand_focused != ExpandFocusType::NotExpanded)
 		{
-			expanded_node = expanded_node->as_group().focused_child;
+			expanded_node = expanded_node->as_group().focused_child.get();
 		}
 
 		if (expanded_node == nullptr) {
@@ -415,7 +416,7 @@ void Hy3Node::recalcSizePosRecursive(CBox offsets, bool no_animation) {
 		bool is_last = (child.get() == group.children.back().get());
 		int inset = is_first && is_last && !this->is_root_group() ? *group_inset : 0;
 
-		if (directly_contains_expanded && child.get() == group.focused_child) {
+		if (directly_contains_expanded && child.get() == group.focused_child.get()) {
 			// Advance offset past this child's visible share
 			if (group.isSplit()) {
 				offset += child->size_ratio * ratio_mul - inset;
@@ -465,7 +466,7 @@ void Hy3Node::recalcSizePosRecursive(CBox offsets, bool no_animation) {
 			double tab_offset = (double)*tab_bar_height + (double)*tab_bar_padding;
 
 			child->visualBox = CBox(tpos.x, tpos.y + tab_offset, tsize.x, tsize.y - tab_offset);
-			child->hidden = this->hidden || expand_focused || group.focused_child != child.get();
+			child->hidden = this->hidden || expand_focused || group.focused_child.get() != child.get();
 
 			// Tab bar makes child non-edge on top
 			child_offsets.x = offsets.x;
@@ -556,10 +557,10 @@ std::string Hy3Node::getTitle() {
 		case Hy3GroupLayout::Tabbed: title = "[T] "; break;
 		}
 
-		if (group.focused_child == nullptr) {
+		if (group.focused_child.get() == nullptr) {
 			title += "Group";
 		} else {
-			title += group.focused_child->getTitle();
+			title += group.focused_child.get()->getTitle();
 		}
 
 		return title;
@@ -620,8 +621,8 @@ std::generator<CWindow&> Hy3Node::windows(bool visibleOnly) {
 		    && (group.isTab()
 		        || group.expand_focused != ExpandFocusType::NotExpanded))
 		{
-			if (group.focused_child != nullptr) {
-				for (auto& window: group.focused_child->windows(true)) {
+			if (group.focused_child.get() != nullptr) {
+				for (auto& window: group.focused_child.get()->windows(true)) {
 					co_yield window;
 				}
 			}
@@ -831,7 +832,7 @@ void Hy3Node::wrap(Hy3GroupLayout layout, GroupEphemeralityOption ephemeral, boo
 	auto& group = group_node.as_group();
 	group.insertChild(std::move(this_up));
 	group.group_focused = false;
-	group.focused_child = this;
+	group.focused_child = this->self;
 	if (ephemeral == GroupEphemeralityOption::Ephemeral
 	    || ephemeral == GroupEphemeralityOption::ForceEphemeral)
 		group.setEphemeral(GroupEphemeralityOption::ForceEphemeral);

--- a/src/Hy3Node.hpp
+++ b/src/Hy3Node.hpp
@@ -132,7 +132,7 @@ struct Hy3GroupNode : Hy3Node {
 	Hy3GroupLayout previous_nontab_layout = Hy3GroupLayout::SplitH;
 	std::list<UP<Hy3Node>> children;
 	bool group_focused = true;
-	Hy3Node* focused_child = nullptr; // non-owning observer, always valid while parent group lives
+	WP<Hy3Node> focused_child; // ponytail: WP prevents use-after-free on extracted/freed nodes
 	ExpandFocusType expand_focused = ExpandFocusType::NotExpanded;
 	Ephemeral ephemeral = Ephemeral::Off;
 	bool locked = false;

--- a/src/TabGroup.cpp
+++ b/src/TabGroup.cpp
@@ -492,10 +492,10 @@ void Hy3TabBar::updateNodeList(std::list<UP<Hy3Node>>& nodes) {
 		auto parent_focused = parent->isIndirectlyFocused();
 
 		entry->setFocused(
-		    parent_group.focused_child == node->get() || (parent_group.group_focused && parent_focused)
+		    parent_group.focused_child.get() == node->get() || (parent_group.group_focused && parent_focused)
 		);
 
-		auto active = parent_focused && (parent_group.focused_child == node->get() || parent_group.group_focused);
+		auto active = parent_focused && (parent_group.focused_child.get() == node->get() || parent_group.group_focused);
 		entry->setActive(active);
 
 		auto last_monitor = Desktop::focusState()->monitor();
@@ -635,8 +635,8 @@ void Hy3TabGroup::updateWithGroup(Hy3Node& node, bool warp) {
 	auto locked = node.as_group().locked;
 	if (this->bar.locked->goal() != locked) *this->bar.locked = locked;
 
-	if (node.as_group().focused_child != nullptr) {
-		this->updateStencilWindows(*node.as_group().focused_child);
+	if (node.as_group().focused_child.get() != nullptr) {
+		this->updateStencilWindows(*node.as_group().focused_child.get());
 	}
 
 	if (this->bar.dirty) this->tick();


### PR DESCRIPTION
## Issue

use-after-free crashes in `moveNodeToWorkspace`:

**1. Dangling `focused_child` pointer**
`Hy3GroupNode::focused_child` is a raw `Hy3Node*` that can dangle when a node is freed during tree mutations (e.g. `togglefloating` via `removeTarget`). The next `getWorkspaceFocusedNode` walk follows the dangling pointer, hitting a SEGV in `Hy3Node::root()`.


Reproduction: fullscreen a window, toggle floating (does not deactivate fullscreen), toggle fullscreen (deactivates), move to another workspace.

**Backtrace (identical across crash reports):**

```
#4  hy3.so  Hy3Node::root()+0x10
#5  hy3.so  Hy3Node::layout()+0x9
#6  hy3.so  Hy3Layout::moveNodeToWorkspace()+0x3ee
```

## Fix

**Commit 1 - `focused_child` WP (0d0cce7):**
Change `focused_child` from `Hy3Node*` to `WP<Hy3Node>`. When the owning `UP<Hy3Node>` is destroyed, the weak pointer auto-expires and `.get()` returns `nullptr` instead of dangling memory. All 50 usages updated across `Hy3Node`, `Hy3Layout`, and `TabGroup`.

Also adds a `node != nullptr` guard in `collapseExpansions` and a `focused_child.get() != nullptr` guard in `recalcSizePosRecursive` -- both were pre-existing crash risks if `expand_focused` was set but `focused_child` was null.


## Impact

- Fixes a deterministic crash (SIGSEGV) triggered by a common command sequence
- No API or behavior changes
- Zero runtime cost in the normal path

**DISCLAIMER**: This PR was created with OpenCode's Big Pickle assistance
