### PR TITLE
fix(focus): use visualBox instead of m_reportedPosition for cursor warp

### DIFF
--- a/src/Hy3Node.cpp
+++ b/src/Hy3Node.cpp
@@ -241,7 +241,7 @@ void Hy3Node::focus(bool warp, Desktop::eFocusReason reason) {
 		auto window = this->as_window();
 		window->setHidden(false);
 		Desktop::focusState()->fullWindowFocus(window, reason);
-		if (warp) Hy3Layout::warpCursorToBox(window->m_reportedPosition, window->m_reportedSize);
+		if (warp) Hy3Layout::warpCursorToBox(this->visualBox.pos(), this->visualBox.size());
 		break;
 	}
 	case Hy3NodeType::Group: {


### PR DESCRIPTION
Hyprland 0.56.0 replaced CWindow::m_position (synchronous) with
m_reportedPosition (set asynchronously by sendWindowSize(), deferred via
doLater()). Reading m_reportedPosition immediately after fullWindowFocus()
returns stale coordinates from the previous layout, causing the cursor to warp
to wrong positions.

Use hy3's own visualBox (always up-to-date after recalcGeometry) instead of
relying on Hyprland's async-reported position.

Fixes cursor centering on focused windows and the associated multi-monitor
focus desync caused by warpTo() calling rawMonitorFocus() with the monitor at
the stale cursor position.

Closes: #330